### PR TITLE
delete unnecessary < in spec template

### DIFF
--- a/packages/stencil/src/schematics/component/files/src/__componentFileName__.spec.tsx.template
+++ b/packages/stencil/src/schematics/component/files/src/__componentFileName__.spec.tsx.template
@@ -20,7 +20,7 @@ describe('<%= componentFileName %>', () => {
 
   it('renders with values', async () => {
     const {root} = await newSpecPage({
-      components: [<<%= className %>],
+      components: [<%= className %>],
       html: `<<%= componentFileName %> first="Stencil" last="'Don't call me a framework' JS"></<%= componentFileName %>>`
     });
     expect(root).toEqualHtml(`


### PR DESCRIPTION
First of all, thank you very much for this awesome project :fire::pray:

There is a unnecessary < in the spec template for generating components thats generate following error.

<img width="352" alt="Bildschirmfoto 2020-07-10 um 11 21 22" src="https://user-images.githubusercontent.com/6680618/87138966-88447d80-c29f-11ea-8a44-a3b38bf81fd8.png">
