### PR TITLE
Add required < in spec file html

### DIFF
--- a/packages/stencil/src/schematics/component/files/src/__componentFileName__.spec.tsx.template
+++ b/packages/stencil/src/schematics/component/files/src/__componentFileName__.spec.tsx.template
@@ -5,7 +5,7 @@ describe('<%= componentFileName %>', () => {
   it('renders', async () => {
     const {root} = await newSpecPage({
       components: [<%= className %>],
-      html: '<%= componentFileName %>></<%= componentFileName %>>'
+      html: '<<%= componentFileName %>></<%= componentFileName %>>'
     });
     expect(root).toEqualHtml(`
       <<%= componentFileName %>>


### PR DESCRIPTION
This PR adds a previously missing `<` in the html in the first test of the spec file template.