### PR TITLE
fix(dev-server): normalize project root before replacement

### DIFF
--- a/packages/stencil/src/builders/utils/stencil-runtime.ts
+++ b/packages/stencil/src/builders/utils/stencil-runtime.ts
@@ -205,7 +205,7 @@ export function createStencilConfig(
         root: getSystemPath(
           normalize(
             normalize(values.config.devServer.root).replace(
-              values.projectRoot,
+              normalize(values.projectRoot),
               values.distDir
             )
           )


### PR DESCRIPTION
fix #54

Replacing `projectRoot` in the normalized `values.config.devServer.root` does not work, if `projectRoot` is not normalized as well. The replacement value will be normalized by the surrounding `normalize` call.

This issue can be reproduced on windows machines where `values.projectRoot` is a Windows-formatted path whereas `normalize(values.config.devServer.root)` returns a Unix-formatted path.