### PR TITLE
feat(svelte): add terser for production builds

### DIFF
--- a/packages/svelte/src/builders/utils/rollup.ts
+++ b/packages/svelte/src/builders/utils/rollup.ts
@@ -19,6 +19,7 @@ const svelte = require('rollup-plugin-svelte');
 const copy = require('rollup-plugin-copy');
 const serve = require('rollup-plugin-serve');
 const livereload = require('rollup-plugin-livereload');
+const { terser } = require('rollup-plugin-terser');
 
 /* eslint-enable */
 
@@ -59,6 +60,13 @@ export function createRollupOptions(
       dedupe: ['svelte'],
     }),
     commonjs(),
+
+    options.prod &&
+      terser({
+        output: {
+          comments: false,
+        },
+      }),
   ];
 
   if (options.serve) {


### PR DESCRIPTION
Add terser to production builds for Svelte (rollup).

BREAKING CHANGE: this may have the potential to break some builds as the output (hash)
will be different. It will also remove any comments in the output bundles.