### PR TITLE
Enable error reporting

### DIFF
--- a/packages/stencil/src/builders/build/builder.ts
+++ b/packages/stencil/src/builders/build/builder.ts
@@ -57,7 +57,7 @@ export function runBuilder(
         );
       }
     }),
-    createStencilProcess()
+    createStencilProcess(context)
   );
 }
 

--- a/packages/stencil/src/builders/e2e/builder.ts
+++ b/packages/stencil/src/builders/e2e/builder.ts
@@ -34,7 +34,7 @@ export function runBuilder(
     options,
     context,
     createStencilCompilerOptions
-  ).pipe(createStencilProcess());
+  ).pipe(createStencilProcess(context));
 }
 
 export default createBuilder(runBuilder);

--- a/packages/stencil/src/builders/stencil-runtime/stencil-process.ts
+++ b/packages/stencil/src/builders/stencil-runtime/stencil-process.ts
@@ -1,11 +1,11 @@
 import { from, Observable, of } from 'rxjs';
-import { BuilderOutput } from '@angular-devkit/architect';
+import { BuilderOutput, BuilderContext } from '@angular-devkit/architect';
 import { catchError, map, switchMap } from 'rxjs/operators';
 import { runTask } from '@stencil/core/cli';
 import { cleanupE2eTesting } from './e2e-testing';
 import { ConfigAndCoreCompiler } from './types';
 
-export function createStencilProcess() {
+export function createStencilProcess(context: BuilderContext) {
   return function(
     source: Observable<ConfigAndCoreCompiler>
   ): Observable<BuilderOutput> {
@@ -17,10 +17,11 @@ export function createStencilProcess() {
             cleanupE2eTesting()
           )
       ),
-      map(() => ({ success: true })),
       catchError((err) => {
+        context.logger.error(err.message);
         return of({ success: false, error: err.message });
-      })
+      }),
+      map(() => ({ success: true })),
     );
   };
 }

--- a/packages/stencil/src/builders/test/builder.ts
+++ b/packages/stencil/src/builders/test/builder.ts
@@ -33,7 +33,7 @@ export function runBuilder(
     options,
     context,
     createStencilCompilerOptions
-  ).pipe(createStencilProcess());
+  ).pipe(createStencilProcess(context));
 }
 
 export default createBuilder(runBuilder);


### PR DESCRIPTION
This PR enables some minimal error logging when the Stencil builder fails.

Kind of short on time right this second, but this could probably be enhanced by adding a stack trace if the `--debug` flag is enabled.