### PR TITLE
fix(stencil): keep existing entrypoint config

### DIFF
--- a/.github/workflows/ci-checks-ubuntu.yml
+++ b/.github/workflows/ci-checks-ubuntu.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     env:
       NX_CLOUD_AUTH_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}

--- a/.github/workflows/ci-checks-windows.yml
+++ b/.github/workflows/ci-checks-windows.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     env:
       NX_CLOUD_AUTH_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}

--- a/e2e/stencil-e2e/tests/stencil.test.ts
+++ b/e2e/stencil-e2e/tests/stencil.test.ts
@@ -15,7 +15,7 @@ describe('e2e', () => {
 
   describe('library', () => {
     describe('outputtarget', () => {
-      it(`should generate react lib`, async (done) => {
+      it(`should generate react lib`, async () => {
         const plugin = uniq('lib');
         await runNxCommandAsync(
           `generate @nxext/stencil:lib ${plugin} --style='css' --buildable --e2eTestRunner='none' --junitTestRunner='none'`
@@ -27,11 +27,9 @@ describe('e2e', () => {
         expect(() =>
           checkFilesExist(`libs/${plugin}-react/src/index.ts`)
         ).not.toThrow();
-
-        done();
       });
 
-      it(`should generate angular lib`, async (done) => {
+      it(`should generate angular lib`, async () => {
         const plugin = uniq('lib');
         await runNxCommandAsync(
           `generate @nxext/stencil:lib ${plugin} --style='css' --buildable --e2eTestRunner='none' --junitTestRunner='none'`
@@ -55,11 +53,9 @@ describe('e2e', () => {
             `libs/${plugin}-angular/src/lib/${plugin}-angular.module.ts`
           )
         ).not.toThrow();
-
-        done();
       });
 
-      it(`should stop if lib not buildable`, async (done) => {
+      it(`should stop if lib not buildable`, async () => {
         const plugin = uniq('lib');
         await runNxCommandAsync(
           `generate @nxext/stencil:lib ${plugin} --style='css' --e2eTestRunner='none' --junitTestRunner='none'`
@@ -71,12 +67,10 @@ describe('e2e', () => {
         expect(result.stdout).toContain(
           'Please use a buildable library for custom outputtargets'
         );
-
-        done();
       });
     });
 
-    it('should create src in the specified directory', async (done) => {
+    it('should create src in the specified directory', async () => {
       const plugin = uniq('lib');
       await runNxCommandAsync(
         `generate @nxext/stencil:lib ${plugin} --directory='subdir' --style=css --e2eTestRunner='none' --junitTestRunner='none'`
@@ -84,20 +78,18 @@ describe('e2e', () => {
       expect(() =>
         checkFilesExist(`libs/subdir/${plugin}/stencil.config.ts`)
       ).not.toThrow();
-      done();
     });
 
-    it('should add tags to nx.json', async (done) => {
+    it('should add tags to nx.json', async () => {
       const plugin = uniq('lib');
       await runNxCommandAsync(
         `generate @nxext/stencil:lib ${plugin} --tags e2etag,e2ePackage --style=css --e2eTestRunner='none' --junitTestRunner='none'`
       );
       const nxJson = readJson('nx.json');
       expect(nxJson.projects[plugin].tags).toEqual(['e2etag', 'e2ePackage']);
-      done();
     });
 
-    it(`should build app with scss`, async (done) => {
+    it(`should build app with scss`, async () => {
       const plugin = uniq('lib');
       await runNxCommandAsync(
         `generate @nxext/stencil:lib ${plugin} --style='scss' --buildable --e2eTestRunner='none' --junitTestRunner='none'`
@@ -105,13 +97,13 @@ describe('e2e', () => {
 
       const result = await runNxCommandAsync(`build ${plugin} --dev`);
       expect(result.stdout).toContain('build finished');
-
-      done();
     });
 
-    it('should be able to make a lib buildable', async (done) => {
+    it('should be able to make a lib buildable', async () => {
       const plugin = uniq('lib');
-      await runNxCommandAsync(`generate @nxext/stencil:lib ${plugin} --e2eTestRunner='none' --junitTestRunner='none'`);
+      await runNxCommandAsync(
+        `generate @nxext/stencil:lib ${plugin} --e2eTestRunner='none' --junitTestRunner='none'`
+      );
       await runNxCommandAsync(
         `generate @nxext/stencil:make-lib-buildable ${plugin} --importPath=@my/lib`
       );
@@ -122,14 +114,12 @@ describe('e2e', () => {
       expect(() =>
         checkFilesExist(`libs/${plugin}/stencil.config.ts`)
       ).not.toThrow();
-
-      done();
     });
   });
 
   describe('e2e-pwa', () => {
     describe('--tags', () => {
-      it('should add tags to nx.json', async (done) => {
+      it('should add tags to nx.json', async () => {
         const plugin = uniq('pwa');
         await runNxCommandAsync(
           `generate @nxext/stencil:pwa ${plugin} --tags e2etag,e2ePackage --style=css --e2eTestRunner='none' --junitTestRunner='none'`
@@ -142,13 +132,11 @@ describe('e2e', () => {
             `apps/${plugin}/src/components/app-home/app-home.e2e.ts`
           );
         }).not.toThrow();
-
-        done();
       });
     });
 
     describe('stencil app builder', () => {
-      it(`should bould pwa app with scss`, async (done) => {
+      it(`should bould pwa app with scss`, async () => {
         const plugin = uniq('pwa');
         await runNxCommandAsync(
           `generate @nxext/stencil:pwa ${plugin} --style='scss' --e2eTestRunner='none' --junitTestRunner='none'`
@@ -156,14 +144,12 @@ describe('e2e', () => {
 
         const result = await runNxCommandAsync(`build ${plugin} --dev`);
         expect(result.stdout).toContain('build finished');
-
-        done();
       });
     });
   });
 
   describe('stencil builderoptions', () => {
-    it(`should build with custom stencil config naming`, async (done) => {
+    it(`should build with custom stencil config naming`, async () => {
       const plugin = uniq('library');
 
       await runNxCommandAsync(
@@ -180,11 +166,9 @@ describe('e2e', () => {
         `build ${plugin} --configPath=libs/${plugin}/${uniqConfigFilename}.ts`
       );
       expect(result.stdout).toContain('build finished');
-
-      done();
     });
 
-    it(`should build with custom configPath`, async (done) => {
+    it(`should build with custom configPath`, async () => {
       const plugin = uniq('library');
       await runNxCommandAsync(
         `generate @nxext/stencil:lib ${plugin} --style=scss --buildable --e2eTestRunner='none' --junitTestRunner='none'`
@@ -194,23 +178,20 @@ describe('e2e', () => {
         `build ${plugin} --configPath=libs/${plugin}/stencil.config.ts`
       );
       expect(result.stdout).toContain('build finished');
-
-      done();
     });
   });
 
   describe('application', () => {
-    it('should add tags to nx.json', async (done) => {
+    it('should add tags to nx.json', async () => {
       const plugin = uniq('app3');
       await runNxCommandAsync(
         `generate @nxext/stencil:app ${plugin} --tags e2etag,e2ePackage --style=css --e2eTestRunner='none' --junitTestRunner='none'`
       );
       const nxJson = readJson('nx.json');
       expect(nxJson.projects[plugin].tags).toEqual(['e2etag', 'e2ePackage']);
-      done();
     });
 
-    it(`should build app with css`, async (done) => {
+    it(`should build app with css`, async () => {
       const plugin = uniq('app2');
       await runNxCommandAsync(
         `generate @nxext/stencil:app ${plugin} --style='css' --e2eTestRunner='none' --junitTestRunner='none'`
@@ -224,14 +205,12 @@ describe('e2e', () => {
           normalize(`dist/apps/${plugin}/www/host.config.json`)
         );
       }).not.toThrow();
-
-      done();
     });
   });
 
   /*
   describe('Storybook', () => {
-    it('should build', async (done) => {
+    it('should build', async () => {
       const plugin = uniq('lib');
       await runNxCommandAsync(
         `generate @nxext/stencil:lib ${plugin} --style='css'`
@@ -241,8 +220,6 @@ describe('e2e', () => {
       );
       await runNxCommandAsync(`generate @nxext/stencil:storybook-configuration ${plugin} --configureCypress=false`);
       await runNxCommandAsync(`build-storybook ${plugin}`);
-
-      done();
     })
   })*/
 });

--- a/e2e/svelte-e2e/tests/svelte.test.ts
+++ b/e2e/svelte-e2e/tests/svelte.test.ts
@@ -14,7 +14,7 @@ describe('svelte e2e', () => {
   });
 
   describe('Svelte app', () => {
-    it('should build svelte application', async (done) => {
+    it('should build svelte application', async () => {
       const plugin = uniq('svelte');
       await runNxCommandAsync(`generate @nxext/svelte:app ${plugin}`);
 
@@ -24,40 +24,33 @@ describe('svelte e2e', () => {
       expect(() =>
         checkFilesExist(`dist/apps/${plugin}/index.html`)
       ).not.toThrow();
-
-      done();
     });
 
-    it('should add tags to nx.json', async (done) => {
+    it('should add tags to nx.json', async () => {
       const plugin = uniq('sveltetags');
       await runNxCommandAsync(
         `generate @nxext/svelte:app ${plugin} --tags e2etag,e2ePackage`
       );
       const nxJson = readJson('nx.json');
       expect(nxJson.projects[plugin].tags).toEqual(['e2etag', 'e2ePackage']);
-      done();
     });
 
-    it('should generate app into directory', async (done) => {
+    it('should generate app into directory', async () => {
       await runNxCommandAsync(`generate @nxext/svelte:app project/ui`);
       expect(() =>
         checkFilesExist(`apps/project/ui/src/main.ts`)
       ).not.toThrow();
-
-      done();
     });
 
-    it('should be able to run linter', async (done) => {
+    it('should be able to run linter', async () => {
       const plugin = uniq('sveltelint');
       await runNxCommandAsync(`generate @nxext/svelte:app ${plugin}`);
 
       const result = await runNxCommandAsync(`lint ${plugin}`);
       expect(result.stdout).toContain('All files pass linting');
-
-      done();
     });
 
-    it('should be able to run check', async (done) => {
+    it('should be able to run check', async () => {
       const plugin = uniq('svelteappcheck');
       await runNxCommandAsync(`generate @nxext/svelte:app ${plugin}`);
 
@@ -65,43 +58,35 @@ describe('svelte e2e', () => {
       expect(result.stdout).toContain(
         'svelte-check found 0 errors, 0 warnings and 0 hints'
       );
-
-      done();
     });
   });
 
   describe('Svelte lib', () => {
-    it('should create svelte library', async (done) => {
+    it('should create svelte library', async () => {
       const plugin = uniq('sveltelib');
       await runNxCommandAsync(`generate @nxext/svelte:lib ${plugin}`);
 
       expect(() =>
         checkFilesExist(`libs/${plugin}/src/index.ts`)
       ).not.toThrow();
-
-      done();
     });
 
-    it('should generate lib into directory', async (done) => {
+    it('should generate lib into directory', async () => {
       await runNxCommandAsync(`generate @nxext/svelte:lib project/uilib`);
       expect(() =>
         checkFilesExist(`libs/project/uilib/src/index.ts`)
       ).not.toThrow();
-
-      done();
     });
 
-    it('should be able to run linter', async (done) => {
+    it('should be able to run linter', async () => {
       const plugin = uniq('svelteliblint');
       await runNxCommandAsync(`generate @nxext/svelte:lib ${plugin}`);
 
       const result = await runNxCommandAsync(`lint ${plugin}`);
       expect(result.stdout).toContain('All files pass linting');
-
-      done();
     });
 
-    it('should be able to run check', async (done) => {
+    it('should be able to run check', async () => {
       const plugin = uniq('sveltelibcheck');
       await runNxCommandAsync(`generate @nxext/svelte:lib ${plugin}`);
 
@@ -109,11 +94,9 @@ describe('svelte e2e', () => {
       expect(result.stdout).toContain(
         'svelte-check found 0 errors, 0 warnings and 0 hints'
       );
-
-      done();
     });
 
-    it('should be able build lib if buildable', async (done) => {
+    it('should be able build lib if buildable', async () => {
       const plugin = uniq('sveltelib');
       await runNxCommandAsync(
         `generate @nxext/svelte:lib ${plugin} --buildable`
@@ -125,15 +108,15 @@ describe('svelte e2e', () => {
       expect(() =>
         checkFilesExist(`dist/libs/${plugin}/bundle.js`)
       ).not.toThrow();
-
-      done();
     });
   });
 
   describe('Svelte vite app', () => {
-    it('should build svelte application', async (done) => {
+    it('should build svelte application', async () => {
       const plugin = uniq('svelte');
-      await runNxCommandAsync(`generate @nxext/svelte:app ${plugin} --bundler=vite`);
+      await runNxCommandAsync(
+        `generate @nxext/svelte:app ${plugin} --bundler=vite`
+      );
 
       const result = await runNxCommandAsync(`build ${plugin}`);
       expect(result.stdout).toContain('Bundle complete');
@@ -141,46 +124,45 @@ describe('svelte e2e', () => {
       expect(() =>
         checkFilesExist(`dist/apps/${plugin}/index.html`)
       ).not.toThrow();
-
-      done();
     });
 
-    it('should add tags to nx.json', async (done) => {
+    it('should add tags to nx.json', async () => {
       const plugin = uniq('sveltetags');
       await runNxCommandAsync(
         `generate @nxext/svelte:app ${plugin} --tags e2etag,e2ePackage --bundler=vite`
       );
       const nxJson = readJson('nx.json');
       expect(nxJson.projects[plugin].tags).toEqual(['e2etag', 'e2ePackage']);
-      done();
     });
 
-    it('should generate app into directory', async (done) => {
-      await runNxCommandAsync(`generate @nxext/svelte:app project/uivite --bundler=vite`);
+    it('should generate app into directory', async () => {
+      await runNxCommandAsync(
+        `generate @nxext/svelte:app project/uivite --bundler=vite`
+      );
       expect(() =>
         checkFilesExist(`apps/project/ui/src/main.ts`)
       ).not.toThrow();
-
-      done();
     });
 
-    it('should be able to run linter', async (done) => {
+    it('should be able to run linter', async () => {
       const plugin = uniq('sveltelint');
-      await runNxCommandAsync(`generate @nxext/svelte:app ${plugin} --bundler=vite`);
+      await runNxCommandAsync(
+        `generate @nxext/svelte:app ${plugin} --bundler=vite`
+      );
 
       const result = await runNxCommandAsync(`lint ${plugin}`);
       expect(result.stdout).toContain('All files pass linting');
-
-      done();
     });
 
-    it('should add a experimental note', async (done) => {
+    it('should add a experimental note', async () => {
       const plugin = uniq('sveltenote');
-      const result = await runNxCommandAsync(`generate @nxext/svelte:app ${plugin} --bundler=vite`);
+      const result = await runNxCommandAsync(
+        `generate @nxext/svelte:app ${plugin} --bundler=vite`
+      );
 
-      expect(result.stdout).toContain('The Vite feature is experimental, be aware!!');
-
-      done();
+      expect(result.stdout).toContain(
+        'The Vite feature is experimental, be aware!!'
+      );
     });
   });
 });

--- a/e2e/svelte-e2e/tsconfig.json
+++ b/e2e/svelte-e2e/tsconfig.json
@@ -4,9 +4,6 @@
   "include": [],
   "references": [
     {
-      "path": "./tsconfig.e2e.json"
-    },
-    {
       "path": "./tsconfig.spec.json"
     }
   ]

--- a/e2e/sveltekit-e2e/tests/sveltekit.spec.ts
+++ b/e2e/sveltekit-e2e/tests/sveltekit.spec.ts
@@ -6,7 +6,7 @@ import {
   uniq,
 } from '@nrwl/nx-plugin/testing';
 describe('sveltekit e2e', () => {
-  it('should create sveltekit app', async (done) => {
+  it('should create sveltekit app', async () => {
     const plugin = uniq('sveltekit');
     ensureNxProject('@nxext/sveltekit', 'dist/packages/sveltekit');
     await runNxCommandAsync(`generate @nxext/sveltekit:app ${plugin}`);
@@ -14,23 +14,19 @@ describe('sveltekit e2e', () => {
     const result = await runNxCommandAsync(`build ${plugin}`);
     expect(result.stdout).toContain('modules transformed');
     expect(result.stdout).toContain('Build executed...');
-
-    done();
   });
 
-  it('should lint sveltekit app', async (done) => {
+  it('should lint sveltekit app', async () => {
     const plugin = uniq('sveltekit');
     ensureNxProject('@nxext/sveltekit', 'dist/packages/sveltekit');
     await runNxCommandAsync(`generate @nxext/sveltekit:app ${plugin}`);
 
     const result = await runNxCommandAsync(`lint ${plugin}`);
     expect(result.stdout).toContain('All files pass linting');
-
-    done();
   });
 
   describe('--directory', () => {
-    it('should create src in the specified directory', async (done) => {
+    it('should create src in the specified directory', async () => {
       const plugin = uniq('sveltekit');
       ensureNxProject('@nxext/sveltekit', 'dist/packages/sveltekit');
       await runNxCommandAsync(
@@ -39,12 +35,11 @@ describe('sveltekit e2e', () => {
       expect(() =>
         checkFilesExist(`apps/subdir/${plugin}/src/app.html`)
       ).not.toThrow();
-      done();
     });
   });
 
   describe('--tags', () => {
-    it('should add tags to nx.json', async (done) => {
+    it('should add tags to nx.json', async () => {
       const plugin = uniq('sveltekit');
       ensureNxProject('@nxext/sveltekit', 'dist/packages/sveltekit');
       await runNxCommandAsync(
@@ -52,7 +47,6 @@ describe('sveltekit e2e', () => {
       );
       const nxJson = readJson('nx.json');
       expect(nxJson.projects[plugin].tags).toEqual(['e2etag', 'e2ePackage']);
-      done();
     });
   });
 });

--- a/e2e/sveltekit-e2e/tsconfig.json
+++ b/e2e/sveltekit-e2e/tsconfig.json
@@ -4,9 +4,6 @@
   "include": [],
   "references": [
     {
-      "path": "./tsconfig.e2e.json"
-    },
-    {
       "path": "./tsconfig.spec.json"
     }
   ]

--- a/nx.json
+++ b/nx.json
@@ -16,6 +16,9 @@
     ".eslintrc.json": "*"
   },
   "projects": {
+    "docs-docusaurus": {
+      "tags": []
+    },
     "stencil": {
       "tags": []
     },
@@ -29,9 +32,6 @@
     "svelte-e2e": {
       "tags": [],
       "implicitDependencies": ["svelte", "vite"]
-    },
-    "docs-docusaurus": {
-      "tags": []
     },
     "sveltekit": {
       "tags": []

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "husky": "^4.3.8",
     "ignore": "^5.1.8",
     "jest": "26.6.3",
+    "lint-staged": "11.0.0",
     "path": "^0.12.7",
     "prettier": "2.3.0",
     "pretty-quick": "^3.1.0",
@@ -116,7 +117,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged'"
+      "pre-commit": "lint-staged"
     }
   },
   "lint-staged": {

--- a/packages/stencil/src/generators/make-lib-buildable/make-lib-buildable.spec.ts
+++ b/packages/stencil/src/generators/make-lib-buildable/make-lib-buildable.spec.ts
@@ -8,7 +8,11 @@ import { makeLibBuildableGenerator } from './make-lib-buildable';
 describe('make-lib-buildable schematic', () => {
   let tree: Tree;
   const name = uniq('testproject');
-  const options: MakeLibBuildableSchema = { name, style: SupportedStyles.css, importPath: '@my/lib' };
+  const options: MakeLibBuildableSchema = {
+    name,
+    style: SupportedStyles.css,
+    importPath: '@my/lib',
+  };
 
   beforeEach(async () => {
     tree = await createTestUILib(name, SupportedStyles.css, false);
@@ -18,20 +22,22 @@ describe('make-lib-buildable schematic', () => {
     await makeLibBuildableGenerator(tree, options);
 
     expect(tree.read(`libs/${name}/stencil.config.ts`).toString('utf-8'))
-      .toEqual(`import { Config } from '@stencil/core';
+      .toMatchInlineSnapshot(`
+      "import { Config } from '@stencil/core';
 
-export const config: Config = {
-  namespace: '${name}',
-  taskQueue: 'async'
-,
-  outputTargets: [{
-            type: 'dist',
-            esmLoaderPath: '../loader',
-            dir: '../../dist/libs/${name}/dist',
-          }]
+      export const config: Config = {
+        namespace: '${name}',
+        taskQueue: 'async'
+      ,
+        outputTargets: [{
+                  type: 'dist',
+                  esmLoaderPath: '../loader',
+                  dir: '../../dist/libs/${name}/dist',
+                }]
 
-};
-`);
+      };
+      "
+    `);
   });
 
   it('should add outputTargets', async () => {

--- a/packages/svelte/src/generators/application/files/vite.config.js.template
+++ b/packages/svelte/src/generators/application/files/vite.config.js.template
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite'
-import svelte from '@sveltejs/vite-plugin-svelte'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,8 +18,8 @@
     "paths": {
       "@nxext/stencil": ["packages/stencil/src/index.ts"],
       "@nxext/svelte": ["packages/svelte/src/index.ts"],
-      "@nxext/tailwind": ["packages/tailwind/src/index.ts"],
       "@nxext/sveltekit": ["packages/sveltekit/src/index.ts"],
+      "@nxext/tailwind": ["packages/tailwind/src/index.ts"],
       "@nxext/vite": ["packages/vite/src/index.ts"]
     }
   },

--- a/workspace.json
+++ b/workspace.json
@@ -1,6 +1,25 @@
 {
   "version": 2,
   "projects": {
+    "docs-docusaurus": {
+      "projectType": "application",
+      "root": "packages/docs-docusaurus",
+      "sourceRoot": "packages/docs-docusaurus/src",
+      "targets": {
+        "build": {
+          "executor": "@nx-plus/docusaurus:browser",
+          "options": {
+            "outputPath": "dist/packages/docs-docusaurus"
+          }
+        },
+        "serve": {
+          "executor": "@nx-plus/docusaurus:dev-server",
+          "options": {
+            "port": 3000
+          }
+        }
+      }
+    },
     "stencil": {
       "root": "packages/stencil",
       "sourceRoot": "packages/stencil/src",
@@ -185,25 +204,6 @@
             "npmPackageName": "@nxext/svelte",
             "pluginOutputPath": "dist/packages/svelte",
             "jestConfig": "e2e/svelte-e2e/jest.config.js"
-          }
-        }
-      }
-    },
-    "docs-docusaurus": {
-      "projectType": "application",
-      "root": "packages/docs-docusaurus",
-      "sourceRoot": "packages/docs-docusaurus/src",
-      "targets": {
-        "build": {
-          "executor": "@nx-plus/docusaurus:browser",
-          "options": {
-            "outputPath": "dist/packages/docs-docusaurus"
-          }
-        },
-        "serve": {
-          "executor": "@nx-plus/docusaurus:dev-server",
-          "options": {
-            "port": 3000
           }
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4693,6 +4693,13 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.1:
   dependencies:
     type-fest "^0.11.0"
 
+ansi-escapes@^4.3.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
+  integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
+  dependencies:
+    type-fest "^0.21.3"
+
 ansi-html@0.0.7, ansi-html@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
@@ -5856,6 +5863,14 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
@@ -6062,6 +6077,14 @@ cli-spinners@^2.0.0, cli-spinners@^2.4.0, cli-spinners@^2.5.0:
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.5.0.tgz#12763e47251bf951cb75c201dfa58ff1bcb2d047"
   integrity sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ==
 
+cli-truncate@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
+  integrity sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==
+  dependencies:
+    slice-ansi "^3.0.0"
+    string-width "^4.2.0"
+
 cli-width@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
@@ -6254,7 +6277,7 @@ commander@^6.2.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
-commander@^7.1.0:
+commander@^7.1.0, commander@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
@@ -7090,7 +7113,7 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-debug@*, debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@*, debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -7159,7 +7182,7 @@ decompress-response@^3.3.0:
   dependencies:
     mimic-response "^1.0.0"
 
-dedent@0.7.0:
+dedent@0.7.0, dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
@@ -7718,7 +7741,7 @@ enhanced-resolve@^5.8.0:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
-enquirer@^2.3.5, enquirer@~2.3.6:
+enquirer@^2.3.5, enquirer@^2.3.6, enquirer@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
@@ -11251,6 +11274,40 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
+lint-staged@11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-11.0.0.tgz#24d0a95aa316ba28e257f5c4613369a75a10c712"
+  integrity sha512-3rsRIoyaE8IphSUtO1RVTFl1e0SLBtxxUOPBtHxQgBHS5/i6nqvjcUfNioMa4BU9yGnPzbO+xkfLtXtxBpCzjw==
+  dependencies:
+    chalk "^4.1.1"
+    cli-truncate "^2.1.0"
+    commander "^7.2.0"
+    cosmiconfig "^7.0.0"
+    debug "^4.3.1"
+    dedent "^0.7.0"
+    enquirer "^2.3.6"
+    execa "^5.0.0"
+    listr2 "^3.8.2"
+    log-symbols "^4.1.0"
+    micromatch "^4.0.4"
+    normalize-path "^3.0.0"
+    please-upgrade-node "^3.2.0"
+    string-argv "0.3.1"
+    stringify-object "^3.3.0"
+
+listr2@^3.8.2:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.10.0.tgz#58105a53ed7fa1430d1b738c6055ef7bb006160f"
+  integrity sha512-eP40ZHihu70sSmqFNbNy2NL1YwImmlMmPh9WO5sLmPDleurMHt3n+SwEWNu2kzKScexZnkyFtc1VI0z/TGlmpw==
+  dependencies:
+    cli-truncate "^2.1.0"
+    colorette "^1.2.2"
+    log-update "^4.0.0"
+    p-map "^4.0.0"
+    rxjs "^6.6.7"
+    through "^2.3.8"
+    wrap-ansi "^7.0.0"
+
 livereload-js@^3.1.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/livereload-js/-/livereload-js-3.3.1.tgz#61f887468086762e61fb2987412cf9d1dda99202"
@@ -11494,6 +11551,16 @@ log-symbols@^4.1.0:
   dependencies:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
+
+log-update@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-4.0.0.tgz#589ecd352471f2a1c0c570287543a64dfd20e0a1"
+  integrity sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==
+  dependencies:
+    ansi-escapes "^4.3.0"
+    cli-cursor "^3.1.0"
+    slice-ansi "^4.0.0"
+    wrap-ansi "^6.2.0"
 
 loglevel@^1.6.8:
   version "1.7.0"
@@ -11764,6 +11831,14 @@ micromatch@^4.0.2:
   dependencies:
     braces "^3.0.1"
     picomatch "^2.0.5"
+
+micromatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
+  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.2.3"
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -13093,6 +13168,11 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
+picomatch@^2.2.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
+  integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
 
 pidtree@^0.3.0:
   version "0.3.1"
@@ -15137,7 +15217,7 @@ rxjs@6.6.3, rxjs@^6.4.0, rxjs@^6.5.4:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@6.6.7:
+rxjs@6.6.7, rxjs@^6.6.7:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -15564,6 +15644,15 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+slice-ansi@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-3.0.0.tgz#31ddc10930a1b7e0b67b08c96c2f49b77a789787"
+  integrity sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
+
 slice-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
@@ -15937,6 +16026,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+string-argv@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
+  integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
 string-hash@^1.1.1:
   version "1.1.3"
@@ -16451,7 +16545,7 @@ through2@^2.0.0:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-through@^2.3.6:
+through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -16773,6 +16867,11 @@ type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+type-fest@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
+  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
 type-fest@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
Hey!

Thanks for your great work. We use this plugin for a while already - recently we have the need to set a custom `types` entrypoint. While this works nicely in plain stencil repos, we noticed that it doesn't work within a NX monorepo. The reason is, that it will be overridden by the default config of this plugin.

To fix this, we propose to keep the existing `package.json` entrypoints and to only use the default values if the properties are not set.

While preparing this fix I noticed that the husky pre-commit hook is not working correctly - let me know if I should move the husky fix to a separate PR.

Happy to get your feedback!