### PR TITLE
fix(sveltekit): add missing dep

### DIFF
--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -5,6 +5,7 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "dependencies": {
+    "@angular-devkit/schematics": "^12.1.1",
     "@nrwl/devkit": "^12.5.0"
   }
 }


### PR DESCRIPTION
Hello there 👋 
I was trying to install and use it (and might contribute later).
And it seems there is a missing dep to initiate a project 

The actual is behavior is when you run this command
```
nx g @nxext/sveltekit:app blog
```

it throws `"@angular-devkit/schematics` is missing.

Adding this dep in the package.json solve my issue ^^" 
