### PR TITLE
feat: add proxy support for dev build

### DIFF
--- a/packages/docs-docusaurus/docs/vite/executors/serve.md
+++ b/packages/docs-docusaurus/docs/vite/executors/serve.md
@@ -9,9 +9,26 @@ title: Serve
 nx serve my-app
 ```
 
-
 ### --configFile
 
 Type: `string`
 
 The path to vite.config.js file.
+
+### --proxyConfig
+
+Type: `string`
+
+The path to proxy.conf.json file.
+
+#### Examples
+
+```json
+{
+  "/foo": "http://localhost:4567",
+  "/api": {
+    "target": "http://jsonplaceholder.typicode.com",
+    "changeOrigin": true
+  }
+}
+```

--- a/packages/docs-docusaurus/docs/vite/overview.md
+++ b/packages/docs-docusaurus/docs/vite/overview.md
@@ -3,4 +3,4 @@ id: overview
 title: Overview
 ---
 
-[@nxext/vite](https://github.com/nxext/nx-extensions/tree/master/packages/vite) is a nx plugin to bring [Solid](https://solid.dev/) to [Nx](https://nx.dev/).
+[@nxext/vite](https://github.com/nxext/nx-extensions/tree/master/packages/vite) is a nx plugin to bring [Solid](https://solid.dev/) and [Svelte](https://svelte.dev/) to [Nx](https://nx.dev/).

--- a/packages/vite/src/executors/dev/schema.d.ts
+++ b/packages/vite/src/executors/dev/schema.d.ts
@@ -2,4 +2,5 @@ export interface DevExecutorSchema {
   configFile?: string;
   baseHref?: string;
   fileReplacements?: { file: string; with: string }[];
+  proxyConfig?: string;
 }

--- a/packages/vite/src/executors/dev/schema.json
+++ b/packages/vite/src/executors/dev/schema.json
@@ -13,6 +13,10 @@
       "type": "string",
       "description": "Base url for the application being built."
     },
+    "proxyConfig": {
+      "type": "string",
+      "description": "Path to the proxy configuration file."
+    },
     "fileReplacements": {
       "description": "Replace files with other files in the build.",
       "type": "array",


### PR DESCRIPTION
This starts to address the issue with #305.

How to use:

Add proxy.conf.json into your project root

Example proxy.conf.json:
```
{
  "/foo": "http://localhost:4567",
  "/api": {
    "target": "http://jsonplaceholder.typicode.com",
    "changeOrigin": true,
  }
}
```

Things to do after PR:

Migration script for svelte from rollbar over to vite.