### PR TITLE
Add port to sveltekit options

### DIFF
--- a/packages/sveltekit/src/executors/sveltekit/executor.ts
+++ b/packages/sveltekit/src/executors/sveltekit/executor.ts
@@ -10,7 +10,7 @@ export default async function runExecutor(
   const projectRoot = joinPathFragments(`${context.root}/${projectDir}`);
 
   const result = await runCommands({
-    command: `svelte-kit ${options.command}`,
+    command: `svelte-kit ${options.command} -p ${options.port}`,
     cwd: projectRoot,
     parallel: false,
     color: true

--- a/packages/sveltekit/src/executors/sveltekit/executor.ts
+++ b/packages/sveltekit/src/executors/sveltekit/executor.ts
@@ -9,14 +9,17 @@ export default async function runExecutor(
   const projectDir = context.workspace.projects[context.projectName].root;
   const projectRoot = joinPathFragments(`${context.root}/${projectDir}`);
 
-  const result = await runCommands({
-    command: `svelte-kit ${options.command} -p ${options.port}`,
-    cwd: projectRoot,
-    parallel: false,
-    color: true
-  }, context);
+  const result = await runCommands(
+    {
+      command: `svelte-kit ${options.command} -p ${options.port}`,
+      cwd: projectRoot,
+      parallel: false,
+      color: true,
+    },
+    context
+  );
 
-  if(result.success) {
+  if (result.success) {
     logger.info('Build executed...');
   } else {
     logger.error('Error while building...');
@@ -24,4 +27,3 @@ export default async function runExecutor(
 
   return result;
 }
-

--- a/packages/sveltekit/src/executors/sveltekit/schema.d.ts
+++ b/packages/sveltekit/src/executors/sveltekit/schema.d.ts
@@ -1,3 +1,4 @@
 export interface SveltekitExecutorOptions {
-  command: string
+  command: string;
+  port: number;
 }

--- a/packages/sveltekit/src/executors/sveltekit/schema.json
+++ b/packages/sveltekit/src/executors/sveltekit/schema.json
@@ -8,6 +8,11 @@
     "command": {
       "type": "string",
       "description": "Sveltekit command to run"
+    },
+    "port": {
+      "type": "number",
+      "description": "Port to listen on.",
+      "default": 3000
     }
   },
   "required": [

--- a/packages/sveltekit/src/executors/sveltekit/schema.json
+++ b/packages/sveltekit/src/executors/sveltekit/schema.json
@@ -15,7 +15,5 @@
       "default": 3000
     }
   },
-  "required": [
-    "command"
-  ]
+  "required": ["command"]
 }

--- a/packages/sveltekit/src/generators/application/schema.d.ts
+++ b/packages/sveltekit/src/generators/application/schema.d.ts
@@ -4,6 +4,7 @@ export interface SveltekitGeneratorSchema {
   name: string;
   tags?: string;
   directory?: string;
+  port?: number;
   skipFormat: boolean;
   linter: Linter;
 }

--- a/packages/sveltekit/src/generators/application/schema.json
+++ b/packages/sveltekit/src/generators/application/schema.json
@@ -24,6 +24,11 @@
       "description": "A directory where the project is placed",
       "alias": "d"
     },
+    "port": {
+      "type": "number",
+      "description": "Port to listen on.",
+      "default": 3000
+    },
     "linter": {
       "description": "The tool to use for running lint checks.",
       "type": "string",


### PR DESCRIPTION
Whilst using the sveltekit package I noticed that I couldn't specify a custom port in the options like you can do in the other packages. This pull request adds this ability.