### PR TITLE
feat(vite): add outDir option for vite build executor

### DIFF
--- a/docs/docs/vite/executors/build.md
+++ b/docs/docs/vite/executors/build.md
@@ -46,3 +46,9 @@ The file to replace with.
 Type: `string`
 
 The path to vite.config.js for the framework.
+
+### outDir
+
+Type: `string`
+
+Path to the build output directory

--- a/packages/vite/src/executors/build/executor.ts
+++ b/packages/vite/src/executors/build/executor.ts
@@ -45,7 +45,7 @@ export default async function runExecutor(
       root: projectRoot,
       base: options.baseHref ?? '/',
       build: {
-        outDir: relative(
+        outDir:  joinPathFragments(`${context.root}/${options.outDir}`) ?? relative(
           projectRoot,
           joinPathFragments(`${context.root}/dist/${projectDir}`)
         ),

--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -3,4 +3,5 @@ export interface BuildExecutorSchema {
   baseHref?: string;
   frameworkConfigFile?: string;
   fileReplacements?: { file: string; with: string }[];
+  outDir?: string
 }

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -37,6 +37,10 @@
         "required": ["replace", "with"]
       },
       "default": []
+    },
+    "outDir": {
+      "type": "string",
+      "description": "Path to the build output directory"
     }
   },
   "required": []


### PR DESCRIPTION
Currently there is no option to overwrite the path where the build directory is located for the vite package. I have added an outDir option to the nxext-vite build executor.