### PR TITLE
Sveltekit update

### DIFF
--- a/packages/sveltekit/src/executors/sveltekit/executor.ts
+++ b/packages/sveltekit/src/executors/sveltekit/executor.ts
@@ -12,7 +12,16 @@ export default async function runExecutor(
 
   const result = await runCommands(
     {
-      command: `svelte-kit ${options.command}${portOption}`,
+      commands: [
+        {
+          command: 'cp package.json ../../dist/packages/' + context.projectName,
+          description: 'coppying the package.json to dist',
+        },
+        {
+          command: `svelte-kit ${options.command}${portOption}`,
+          description: 'Executing svelte-kit command',
+        },
+      ],
       cwd: projectRoot,
       parallel: false,
       color: true,

--- a/packages/sveltekit/src/executors/sveltekit/executor.ts
+++ b/packages/sveltekit/src/executors/sveltekit/executor.ts
@@ -9,20 +9,32 @@ export default async function runExecutor(
   const projectDir = context.workspace.projects[context.projectName].root;
   const projectRoot = joinPathFragments(`${context.root}/${projectDir}`);
   const portOption = options.command === 'dev' ? ` --port ${options.port}` : '';
+  const projectOutput = joinPathFragments(
+    context.root,
+    'dist/packages/',
+    context.projectName
+  );
 
   const result = await runCommands(
     {
+      cwd: projectRoot,
       commands: [
+        {
+          // creates folder if it doesn't exist
+          // otherwhise cp command doesn't work
+          command: `mkdir -p ${projectOutput}`,
+          description: 'Creating output folder',
+        },
         {
           command: 'cp package.json ../../dist/packages/' + context.projectName,
           description: 'coppying the package.json to dist',
         },
+        // svelte-kit on serving, looks to the nearest parent package.json
         {
           command: `svelte-kit ${options.command}${portOption}`,
           description: 'Executing svelte-kit command',
         },
       ],
-      cwd: projectRoot,
       parallel: false,
       color: true,
     },

--- a/packages/sveltekit/src/generators/application/files/svelte.config.js__template__
+++ b/packages/sveltekit/src/generators/application/files/svelte.config.js__template__
@@ -9,8 +9,8 @@ const config = {
   preprocess: preprocess(),
 
   kit: {
-    adapter: adapter({ out: '../../dist/packages/<%= fileName %>' }),
-    outDir: resolve('./../../dist/packages/<%= fileName %>'),
+    adapter: adapter({ out: './<%= distDir %>' }),
+    outDir: resolve('./<%= distDir %>'),
     vite: {
       resolve: {
         alias: {

--- a/packages/sveltekit/src/generators/application/files/svelte.config.js__template__
+++ b/packages/sveltekit/src/generators/application/files/svelte.config.js__template__
@@ -1,10 +1,27 @@
+import adapter from '@sveltejs/adapter-auto';
 import preprocess from 'svelte-preprocess';
+import { resolve } from 'path';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// Consult https://github.com/sveltejs/svelte-preprocess
-	// for more information about preprocessors
-	preprocess: preprocess()
+  // Consult https://github.com/sveltejs/svelte-preprocess
+  // for more information about preprocessors
+  preprocess: preprocess(),
+
+  kit: {
+    adapter: adapter({ out: '../../dist/packages/skit' }),
+    outDir: resolve('./../../dist/packages/skit'),
+    vite: {
+      resolve: {
+        alias: {
+          // these are the aliases and paths to them
+          '@components': resolve('./../uikit/src'),
+          '@lib': resolve('./src/lib'),
+          '@utils': resolve('./src/lib/utils'),
+        },
+      },
+    },
+  },
 };
 
 export default config;

--- a/packages/sveltekit/src/generators/application/files/svelte.config.js__template__
+++ b/packages/sveltekit/src/generators/application/files/svelte.config.js__template__
@@ -9,13 +9,12 @@ const config = {
   preprocess: preprocess(),
 
   kit: {
-    adapter: adapter({ out: '../../dist/packages/skit' }),
-    outDir: resolve('./../../dist/packages/skit'),
+    adapter: adapter({ out: '../../dist/packages/<%= fileName %>' }),
+    outDir: resolve('./../../dist/packages/<%= fileName %>'),
     vite: {
       resolve: {
         alias: {
           // these are the aliases and paths to them
-          '@components': resolve('./../uikit/src'),
           '@lib': resolve('./src/lib'),
           '@utils': resolve('./src/lib/utils'),
         },

--- a/packages/sveltekit/src/generators/application/files/tsconfig.json.template
+++ b/packages/sveltekit/src/generators/application/files/tsconfig.json.template
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
+  "extends": "<%= sveltekitGeneratedConfig %>",
 
   "compilerOptions": {
     "moduleResolution": "node",

--- a/packages/sveltekit/src/generators/application/generator.ts
+++ b/packages/sveltekit/src/generators/application/generator.ts
@@ -2,11 +2,13 @@ import {
   addProjectConfiguration,
   formatFiles,
   generateFiles,
-  getWorkspaceLayout, joinPathFragments,
+  getWorkspaceLayout,
+  joinPathFragments,
   names,
   getWorkspacePath,
   offsetFromRoot,
-  Tree, convertNxGenerator
+  Tree,
+  convertNxGenerator,
 } from '@nrwl/devkit';
 import * as path from 'path';
 import { NormalizedSchema, SveltekitGeneratorSchema } from './schema';
@@ -30,7 +32,10 @@ function normalizeOptions(
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())
     : [];
-  const distDir = relative(joinPathFragments(`${workspacePath}/${projectRoot}`), joinPathFragments(`${workspacePath}/dist/${projectRoot}`));
+  const distDir = relative(
+    joinPathFragments(`${workspacePath}/${projectRoot}`),
+    joinPathFragments(`${workspacePath}/dist/${projectRoot}`)
+  );
 
   return {
     ...options,
@@ -47,6 +52,7 @@ function addFiles(host: Tree, options: NormalizedSchema) {
     ...options,
     ...names(options.name),
     offsetFromRoot: offsetFromRoot(options.projectRoot),
+    sveltekitGeneratedConfig: options.distDir + '/tsconfig.json',
     template: '',
   };
   generateFiles(
@@ -57,7 +63,10 @@ function addFiles(host: Tree, options: NormalizedSchema) {
   );
 }
 
-export async function applicationGenerator(host: Tree, schema: SveltekitGeneratorSchema) {
+export async function applicationGenerator(
+  host: Tree,
+  schema: SveltekitGeneratorSchema
+) {
   const options = normalizeOptions(host, schema);
   addProjectConfiguration(host, options.projectName, {
     root: options.projectRoot,
@@ -67,25 +76,25 @@ export async function applicationGenerator(host: Tree, schema: SveltekitGenerato
       build: {
         executor: '@nxext/sveltekit:sveltekit',
         options: {
-          command: 'build'
-        }
+          command: 'build',
+        },
       },
       serve: {
         executor: '@nxext/sveltekit:sveltekit',
         options: {
-          command: 'dev'
-        }
+          command: 'dev',
+        },
       },
       add: {
         executor: '@nxext/sveltekit:add',
-      }
+      },
     },
     tags: options.parsedTags,
   });
   addFiles(host, options);
   const lintTask = await addLinting(host, options);
 
-  if(!options.skipFormat) {
+  if (!options.skipFormat) {
     await formatFiles(host);
   }
 

--- a/packages/sveltekit/src/generators/application/lib/install-dependencies.ts
+++ b/packages/sveltekit/src/generators/application/lib/install-dependencies.ts
@@ -5,6 +5,7 @@ import {
   svelteKitVersion,
   sveltePreprocessVersion,
   svelteVersion,
+  svelteKitAdapertAutoVersion,
 } from '../../utils/versions';
 
 export function installDependencies(host: Tree) {
@@ -18,6 +19,7 @@ export function installDependencies(host: Tree) {
       '@sveltejs/kit': svelteKitVersion,
       svelte: svelteVersion,
       'svelte-preprocess': sveltePreprocessVersion,
+      '@sveltejs/adapter-auto': svelteKitAdapertAutoVersion,
     }
   );
 }

--- a/packages/sveltekit/src/generators/utils/versions.ts
+++ b/packages/sveltekit/src/generators/utils/versions.ts
@@ -4,3 +4,4 @@ export const svelteKitVersion = 'next';
 export const svelteKitAdapterVersion = 'next';
 export const sveltePreprocessVersion = '^4.9.4';
 export const svelteKitAdapertAutoVersion = 'next';
+export const angularSchematicsVersion = '^13.0.0';

--- a/packages/sveltekit/src/generators/utils/versions.ts
+++ b/packages/sveltekit/src/generators/utils/versions.ts
@@ -3,4 +3,4 @@ export const svelteVersion = '^3.44.0';
 export const svelteKitVersion = 'next';
 export const svelteKitAdapterVersion = 'next';
 export const sveltePreprocessVersion = '^4.9.4';
-export const angularSchematicsVersion = '^13.0.0';
+export const svelteKitAdapertAutoVersion = 'next';


### PR DESCRIPTION
### Updating sveltekit plugin

Updates:
. The output folder for serving (.sveltekit) generated at the root of the project folder is no longer but instead in the dist folder.
. The tsconfig generated by sveltekit now extends the tsconfig.base (only on build, needs adjust for serving)