### PR TITLE
minor fixes svelte -> sveltekit

### DIFF
--- a/packages/sveltekit/src/generators/application/files/src/app.html__template__
+++ b/packages/sveltekit/src/generators/application/files/src/app.html__template__
@@ -4,9 +4,9 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		%svelte.head%
+		%sveltekit.head%
 	</head>
 	<body>
-		<div id="svelte">%svelte.body%</div>
+		<div id="svelte">%sveltekit.body%</div>
 	</body>
 </html>


### PR DESCRIPTION
This fixes minor issues in the HTML template where the preprocessor wants %sveltekit.body% instead of %svelte.body%

e2e failed before, but passes with this change.