### PR TITLE
Updates for stencil storybook babel

### DIFF
--- a/packages/stencil/src/generators/component/files/component/__componentFileName__.stories.tsx.template
+++ b/packages/stencil/src/generators/component/files/component/__componentFileName__.stories.tsx.template
@@ -1,13 +1,5 @@
 import { h } from '@stencil/core';
 
-// To satisfy Storybook when Webpack is building stories,
-// keep reference of `h` here. Otherwise it will be omitted
-// during compilation and runtime error will occurr. This is
-// a limitation of Stencil's compiler api and an alternative
-// to using 'lit-html' as stated here: 
-// https://github.com/ionic-team/stencil/issues/3104
-h;
-
 export default {
   title: '<%= className %>',
   component: <%= className %> 

--- a/packages/stencil/src/generators/storybook-configuration/project-files/.babelrc.json
+++ b/packages/stencil/src/generators/storybook-configuration/project-files/.babelrc.json
@@ -1,0 +1,11 @@
+{
+  "presets": [
+    [
+      // @see https://babeljs.io/docs/en/babel-preset-typescript
+      "@babel/preset-typescript",
+      {
+        "onlyRemoveTypeImports": true
+      }
+    ]
+  ]
+}

--- a/packages/stencil/src/generators/storybook-configuration/project-files/__dot__storybook/main.ts__tmpl__
+++ b/packages/stencil/src/generators/storybook-configuration/project-files/__dot__storybook/main.ts__tmpl__
@@ -5,23 +5,24 @@ import {config as rootMain} from '<%= offsetFromRoot %>../.storybook/main';
 
 /**
  * @see https://github.com/storybookjs/storybook/blob/main/docs/configure/overview.md#using-storybook-api
+ * @see https://github.com/storybookjs/storybook/blob/main/lib/client-logger/src/index.ts
  */
-const config: StorybookConfig = {
+export default {
   ...rootMain,
   stories: [
     ...rootMain.stories,
     '../src/**/*.stories.mdx',
-    '../src/**/*.stories.@(js|jsx|ts|tsx)'
+    '../src/**/*.stories.@(js|jsx|ts|tsx)',
   ],
-  framework: "@storybook/html",
+  framework: '@storybook/html',
+  logLevel: 'warn',
   webpackFinal: async (config: Configuration, options: Options) => {
-    // apply any global webpack configs that might have been specified in .storybook/main.js
+    // apply any global webpack configs that might have been specified in .storybook/main.ts
     if (rootMain.webpackFinal) {
       config = await rootMain.webpackFinal(config, options);
     }
-
+  
     // add your own webpack tweaks if needed
     return config;
   },
-};
-module.exports = config;
+} as StorybookConfig;

--- a/packages/stencil/src/generators/storybook-configuration/root-files/__dot__storybook/main.ts__tmpl__
+++ b/packages/stencil/src/generators/storybook-configuration/root-files/__dot__storybook/main.ts__tmpl__
@@ -1,8 +1,9 @@
 // Imports the Storybook's configuration and options API
 import type { StorybookConfig, Options } from '@storybook/core-common';
-import type { Configuration } from 'webpack';
-import { TsconfigPathsPlugin } from "tsconfig-paths-webpack-plugin";
-import { logger } from "@storybook/node-logger";
+import type { Configuration, RuleSetRule } from 'webpack';
+import { TsconfigPathsPlugin } from 'tsconfig-paths-webpack-plugin';
+import { logger } from '@storybook/node-logger';
+import { filterByLoaderName } from './utils/webpack-module-rules';
 
 /**
  * @see https://github.com/storybookjs/storybook/blob/main/docs/configure/overview.md#using-storybook-api
@@ -14,8 +15,8 @@ export const config: StorybookConfig = {
       name: 'webpack5',
       options: {
         fsCache: false,
-        lazyCompilation: false
-     },
+        lazyCompilation: false,
+      },
     },
   },
   // @see https://github.com/storybookjs/storybook/blob/main/docs/configure/overview.md#feature-flags
@@ -25,26 +26,30 @@ export const config: StorybookConfig = {
   },
   stories: [],
   webpackFinal: async (config: Configuration, options: Options) => {
-    // `configType` has a value of 'DEVELOPMENT' or 'PRODUCTION'
-    // options.configType = 'DEVELOPMENT';
-
+    // `options.configType` has a value of 'DEVELOPMENT' or 'PRODUCTION'
     // You can change the configuration based on that.
     // 'PRODUCTION' is used when building the static version of storybook.
-    const resolve = config?.resolve;
-    if(!resolve) {
-      logger.error(`No resolve object assigned to Webpack's config. This is needed for Storybook.`);
-      throw new Error();
-    }
 
+    const {resolve, module} = config;
+    if(!resolve) throw new Error(`No resolve object assigned to Webpack's config. This is needed for Storybook.`);
+
+    // Make whatever fine-grained changes you need
     const tsPaths = new TsconfigPathsPlugin({
       configFile: './<%= rootTsConfigPath %>',
-      extensions: resolve?.extensions,
-      mainFields: resolve?.mainFields as string[],
-     });
-  
-    resolve?.plugins
+      extensions: resolve.extensions,
+      mainFields: resolve.mainFields as string[],
+    });
+
+    resolve.plugins
       ? resolve.plugins.push(tsPaths)
       : (resolve.plugins = [tsPaths]);
+
+    module?.rules?.forEach((rule: RuleSetRule | '...') => {
+      // modify all 'babel-loader' occurrences by setting rootMode to 'upward'. this is needed in
+      // babel 7+ to include any Nx projects having a `.babelrc.json` file to be processed. these files
+      // must enable `onlyRemoveTypeImports` for stencil's 'h' module is not removed in stories.
+      filterByLoaderName(rule, 'babel-loader')?.forEach(ele => (ele.options = { ...ele.options, rootMode: 'upward' }));
+    });
 
     const instance = (await options.presets.apply('webpackInstance')) as any;
     logger.info(`=> Running in webpack instance: ${instance?.version}`);

--- a/packages/stencil/src/generators/storybook-configuration/root-files/__dot__storybook/utils/webpack-module-rules.ts__tmpl__
+++ b/packages/stencil/src/generators/storybook-configuration/root-files/__dot__storybook/utils/webpack-module-rules.ts__tmpl__
@@ -1,0 +1,54 @@
+import type { RuleSetRule, RuleSetUseItem } from 'webpack';
+
+/**
+ * This type is a member from the `RuleSetUseItem` union type declared by Webpack. The
+ * other member of that union type is a string.
+ */
+ type ObjectTypeRuleSetUseItem = {loader?: string, options?: { [index: string]: any }};
+
+ /**
+  * Since `RuleSetUse` union type has multiple members of different types, this returns
+  * `true` if the `rule.use` property is an Array.
+  */
+ const isArrayTypeUsePropPresent = (use: unknown): use is Array<unknown> => use instanceof Array;
+ 
+ /**
+  * Since `RuleSetUseItem` union type has multiple members of different types, this returns
+  * `true` if parameter is `ObjectTypeRuleSetUseItem` type.
+  */
+ const isObjectTypeRuleSetUseItem = (ele: RuleSetUseItem): ele is Required<ObjectTypeRuleSetUseItem> => {
+   return (typeof ele === 'object') && (typeof ele?.loader === 'string') && (typeof ele?.options === 'object');
+ }
+ 
+ /**
+  * With a given `rule` and `name` of a Webpack loader (e.g.: 'babel-loader'), return all occurrences from 
+  * `rule.use` collection.
+  * 
+  * This has been developed to specifically for 'babel-loader' although will work with other loaders of 
+  * *same shape*. Same shape since Webpack's `rules` property, although typed, has objects of union types 
+  * with most having multiple members.
+  * 
+  * @see https://webpack.js.org/configuration/module/#modulerules
+  * @see https://webpack.js.org/loaders/
+  * @see https://webpack.js.org/loaders/babel-loader
+  */
+ export function filterByLoaderName(rule: RuleSetRule | '...', name: string): Array<Required<ObjectTypeRuleSetUseItem>> | undefined {
+     // RegExp to match file path segments
+     const pathSegment = /(?!\\|\/)[-\w]+(?=\\|\/)/g;
+     
+     /**
+      * Returns `true` if the `rule.use[n].loader` value has `name` value in it.
+      * Prior to using this predicate, verify that `ele` has values by using `isObjectTypeRuleSetUseItem`.
+      */
+     const isUseLoaderByName = (ele: Required<ObjectTypeRuleSetUseItem>): boolean => {
+       return Array.from(ele.loader.matchAll(pathSegment)).map(e => e.pop()).some(e => e === name);
+     }
+ 
+     if (typeof rule === 'object') {
+       return isArrayTypeUsePropPresent(rule.use)
+           ? rule.use.filter(isObjectTypeRuleSetUseItem).filter(isUseLoaderByName)
+           : undefined;
+     } else if (typeof rule === 'string') {
+       return undefined;
+     }
+ }

--- a/packages/stencil/src/generators/storybook-configuration/root-files/babel.config.json
+++ b/packages/stencil/src/generators/storybook-configuration/root-files/babel.config.json
@@ -1,7 +1,24 @@
 {
+  // @see https://babeljs.io/docs/en/options#sourcetype
+  "sourceType": "unambiguous",
+  // @see https://babeljs.io/docs/en/options#babelrcroots
+  "babelrcRoots": [
+    // Keep the root as a root
+    ".",
+
+    // Also consider monorepo packages "root" and load their .babelrc.json files.
+    "./libs/*"
+  ],
+  // @see https://babeljs.io/docs/en/options#presets
   "presets": [
     "@babel/preset-env",
-    "@babel/preset-typescript",
+    [
+      // @see https://babeljs.io/docs/en/babel-preset-typescript
+      "@babel/preset-typescript",
+      {
+        "onlyRemoveTypeImports": false
+      }
+    ],
     [
       // @see https://babeljs.io/docs/en/babel-preset-react
       "@babel/preset-react",

--- a/packages/stencil/src/utils/insert-statement.ts
+++ b/packages/stencil/src/utils/insert-statement.ts
@@ -8,7 +8,7 @@ import {
 /**
  * Insert a statement after the last import statement in a file.
  *
- * For orgin of this function, see link below.
+ * For origin of this function, see link below.
  *
  * @see https://github.com/nrwl/nx/blob/master/packages/workspace/src/generators/utils/insert-statement.ts
  */


### PR DESCRIPTION
In my opening comment in PR #711, I mentioned a caveat that this PR resolves.

Although the Stencil issue/feature I mentioned in a source code comment for that PR is still open, I recently discovered that Babel was not configured to prevent tree shaking which was removing Stencil's `h` module. Setting `onlyRemoveTypeImports` to `true` in Babel config file prevents `h` module from being removed.  

In addition, Babel 7 config file (.babelrc.json) is now deployed for new Stencil Storybook projects. This is for Babel project level adjustments if needed. In order for this to work, babel-loader for Webpack is required to have the following option property: `rootMode: 'upward'`. This property, when config files are being used, can only be set during runtime. This PR programmatically sets that when the root '.storybook/main.ts' file is being processed.

Make edits and please ask for any clarification if needed.

Prior to executing the script below if you choose, run verdaccio locally and: clone, build and publish (`/dist/packages/stencil` package) with semver version of choice. Below I used `14.0.3-local.1`. This script is a smoke test that I used and should launch Storybook with a single story generated.

```shell
npx create-nx-workspace@latest --name nx-workspace --cli nx --preset angular --appName web --style css --packageManager npm --nxCloud false
cd nx-workspace
npm add @nxext/stencil@14.0.3-local.1 --save
git add .
git commit -m "post: npm add @nxext/stencil"
npx nx generate @nxext/stencil:library nx-project --buildable --style css
git add .
git commit -m "post: nx generate @nxext/stencil:library nx-project"
npx nx generate @nxext/stencil:storybook-configuration nx-project --configureCypress true
git add .
git commit -m "post: nx generate @nxext/stencil:storybook-configuration"
npx nx generate @nxext/stencil:component --project nx-project --name test-component
git add .
git commit -m "post: nx generate @nxext/stencil:component"
npx nx generate @nxext/stencil:add-outputtarget --outputType angular --projectName nx-project
git add .
git commit -m "post: nx generate @nxext/stencil:add-outputtarget"
npx nx run nx-project:build
git add .
git commit -m "post: nx run nx-project-build"
npx nx run nx-project:test
npx nx run nx-project:storybook
```