### PR TITLE
fix(react): unitTestRunner failed when jest

### DIFF
--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -1,5 +1,5 @@
 import { readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTestProject } from '../utils/testing';
 import { applicationGenerator } from './application';
 import { Linter } from '@nrwl/linter';
 
@@ -7,7 +7,7 @@ describe('application', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTestProject();
   });
 
   it('should add vite as a devDependency', async () => {

--- a/packages/react/src/generators/init/init.spec.ts
+++ b/packages/react/src/generators/init/init.spec.ts
@@ -1,5 +1,5 @@
 import { readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTestProject } from '../utils/testing';
 
 import { reactInitGenerator } from './init';
 
@@ -7,7 +7,7 @@ describe('init', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTestProject();
   });
 
   it('should not add jest config if unitTestRunner is none', async () => {
@@ -15,9 +15,18 @@ describe('init', () => {
     expect(tree.exists('jest.config.ts')).toEqual(false);
   });
 
-  it('should not add jest config if unitTestRunner is none', async () => {
-    await reactInitGenerator(tree, { unitTestRunner: 'none' });
-    expect(tree.exists('jest.config.ts')).toEqual(false);
+  it('should add jest config if unitTestRunner is jest', async () => {
+    await reactInitGenerator(tree, { unitTestRunner: 'jest' });
+    expect(tree.exists('jest.config.ts')).toEqual(true);
+  });
+
+  it('should add the correct jest plugin version', async (): Promise<void> => {
+    await reactInitGenerator(tree, { unitTestRunner: 'jest' });
+    expect(
+      JSON.parse(tree.read('package.json').toString()).devDependencies[
+        '@nrwl/jest'
+      ]
+    ).toEqual('0.0.0');
   });
 
   it('should add vite as a devDependency', async () => {

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -1,5 +1,5 @@
 import { readJson, Tree } from '@nrwl/devkit';
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import { createTestProject } from '../utils/testing';
 import { libraryGenerator } from './library';
 import { Linter } from '@nrwl/linter';
 
@@ -7,7 +7,7 @@ describe('application', () => {
   let tree: Tree;
 
   beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
+    tree = createTestProject();
   });
 
   it('should add vite as a devDependency', async () => {

--- a/packages/react/src/generators/utils/testing.ts
+++ b/packages/react/src/generators/utils/testing.ts
@@ -1,0 +1,20 @@
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+
+export function createTestProject() {
+  const tree = createTreeWithEmptyWorkspace();
+
+  tree.write(
+    'package.json',
+    `
+      {
+        "name": "test-name",
+        "dependencies": {},
+        "devDependencies": {
+          "@nrwl/workspace": "0.0.0"
+        }
+      }
+    `
+  );
+
+  return tree;
+}


### PR DESCRIPTION
when passing `jest` as the `unitTestRunner` there was no
`@nrlw/workspace` version in `paackage.json` to base the version off for
`@nrwl/jest`.

This fixes that by adding a package.json to the test setup so that there
is always `@nrwl/workspace: 0.0.0` present which mimics the non-test
behaviour.