### PR TITLE
fix(vite): correct fileReplacements property names

### DIFF
--- a/docs/docs/vite/executors/build.md
+++ b/docs/docs/vite/executors/build.md
@@ -24,7 +24,7 @@ Type: `object[]`
 
 Replace files with other files in the build.
 
-#### replace
+#### file
 
 Type: `string`
 

--- a/docs/docs/vite/executors/dev.md
+++ b/docs/docs/vite/executors/dev.md
@@ -24,7 +24,7 @@ Type: `object[]`
 
 Replace files with other files in the build.
 
-#### replace
+#### file
 
 Type: `string`
 

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -33,7 +33,7 @@
       "items": {
         "type": "object",
         "properties": {
-          "replace": {
+          "file": {
             "type": "string",
             "description": "The file to be replaced."
           },
@@ -43,7 +43,7 @@
           }
         },
         "additionalProperties": false,
-        "required": ["replace", "with"]
+        "required": ["file", "with"]
       },
       "default": []
     }

--- a/packages/vite/src/executors/dev/schema.json
+++ b/packages/vite/src/executors/dev/schema.json
@@ -32,7 +32,7 @@
       "items": {
         "type": "object",
         "properties": {
-          "replace": {
+          "file": {
             "type": "string",
             "description": "The file to be replaced."
           },
@@ -42,7 +42,7 @@
           }
         },
         "additionalProperties": false,
-        "required": ["replace", "with"]
+        "required": ["file", "with"]
       },
       "default": []
     }

--- a/packages/vite/src/generators/application/lib/add-project.ts
+++ b/packages/vite/src/generators/application/lib/add-project.ts
@@ -43,7 +43,7 @@ function createBuildTarget(options: NormalizedSchema): TargetConfiguration {
       production: {
         fileReplacements: [
           {
-            replace: joinPathFragments(
+            file: joinPathFragments(
               options.projectRoot,
               `src/environments/environment.ts`
             ),
@@ -70,7 +70,7 @@ function createServeTarget(options: NormalizedSchema): TargetConfiguration {
       production: {
         fileReplacements: [
           {
-            replace: joinPathFragments(
+            file: joinPathFragments(
               options.projectRoot,
               `src/environments/environment.ts`
             ),


### PR DESCRIPTION
function `replaceFiles` expects input of type `{ file: string; with: string }` but current schema declares `{ replace: string; with: string }`