### PR TITLE
fix: set correct Discord server invitation link

### DIFF
--- a/docs/docs/nxext/community.md
+++ b/docs/docs/nxext/community.md
@@ -1,3 +1,3 @@
 # Community
 
-You can find us on [Discord](https://discord.gg/b3Kc39my) or [Github discussions](https://github.com/nxext/nx-extensions/discussions).
+You can find us on [Discord](https://discord.gg/5tUYdY4pUG) or [Github discussions](https://github.com/nxext/nx-extensions/discussions).


### PR DESCRIPTION
as per @Jordan-Hall's message here: https://github.com/nxext/nx-extensions/discussions/453#discussioncomment-2121765, I've just joined the server successfully with this link.