### PR TITLE
fix(capacitor): ensure npx uses @capacitor/cli executable

### DIFF
--- a/docs/docs/ionic-angular/capacitor.md
+++ b/docs/docs/ionic-angular/capacitor.md
@@ -1,4 +1,4 @@
-By default, [Capacitor](https://capacitorjs.com/) is configured for a newly generated project. Typically you execute Capacitor commands with `ionic capacitor ...` or `npx cap --package=@capacitor/cli ...`. However, due to the way that Nx works, the Capacitor commands go through the Nx CLI.
+By default, [Capacitor](https://capacitorjs.com/) is configured for a newly generated project. Typically you execute Capacitor commands with `ionic capacitor ...` or `npx --package=@capacitor/cli cap ...`. However, due to the way that Nx works, the Capacitor commands go through the Nx CLI.
 
 ## Add Native Platform
 

--- a/docs/docs/ionic-angular/capacitor.md
+++ b/docs/docs/ionic-angular/capacitor.md
@@ -1,4 +1,4 @@
-By default, [Capacitor](https://capacitorjs.com/) is configured for a newly generated project. Typically you execute Capacitor commands with `ionic capacitor ...` or `npx cap ...`. However, due to the way that Nx works, the Capacitor commands go through the Nx CLI.
+By default, [Capacitor](https://capacitorjs.com/) is configured for a newly generated project. Typically you execute Capacitor commands with `ionic capacitor ...` or `npx cap --package=@capacitor/cli ...`. However, due to the way that Nx works, the Capacitor commands go through the Nx CLI.
 
 ## Add Native Platform
 

--- a/docs/docs/ionic-react/capacitor.md
+++ b/docs/docs/ionic-react/capacitor.md
@@ -1,4 +1,4 @@
-By default, [Capacitor](https://capacitorjs.com/) is configured for a newly generated project. Typically you execute Capacitor commands with `ionic capacitor ...` or `npx cap --package=@capacitor/cli ...`. However, due to the way that Nx works, the Capacitor commands go through the Nx CLI.
+By default, [Capacitor](https://capacitorjs.com/) is configured for a newly generated project. Typically you execute Capacitor commands with `ionic capacitor ...` or `npx --package=@capacitor/cli cap ...`. However, due to the way that Nx works, the Capacitor commands go through the Nx CLI.
 
 ## Add Native Platform
 

--- a/docs/docs/ionic-react/capacitor.md
+++ b/docs/docs/ionic-react/capacitor.md
@@ -1,4 +1,4 @@
-By default, [Capacitor](https://capacitorjs.com/) is configured for a newly generated project. Typically you execute Capacitor commands with `ionic capacitor ...` or `npx cap ...`. However, due to the way that Nx works, the Capacitor commands go through the Nx CLI.
+By default, [Capacitor](https://capacitorjs.com/) is configured for a newly generated project. Typically you execute Capacitor commands with `ionic capacitor ...` or `npx cap --package=@capacitor/cli ...`. However, due to the way that Nx works, the Capacitor commands go through the Nx CLI.
 
 ## Add Native Platform
 

--- a/packages/capacitor/src/executors/cap/executor.ts
+++ b/packages/capacitor/src/executors/cap/executor.ts
@@ -15,7 +15,7 @@ export default async function runExecutor(
 
   const runCommandsOptions: RunCommandsOptions = {
     cwd: projectRootPath,
-    command: `npx cap --package=@capacitor/cli ${cmd}`,
+    command: `npx --package=@capacitor/cli cap ${cmd}`,
     __unparsed__: [],
   };
 

--- a/packages/capacitor/src/executors/cap/executor.ts
+++ b/packages/capacitor/src/executors/cap/executor.ts
@@ -15,7 +15,7 @@ export default async function runExecutor(
 
   const runCommandsOptions: RunCommandsOptions = {
     cwd: projectRootPath,
-    command: `npx cap ${cmd}`,
+    command: `npx cap --package=@capacitor/cli ${cmd}`,
     __unparsed__: [],
   };
 


### PR DESCRIPTION
# Description

As stated in following [nxtend issue](https://github.com/nxtend-team/nxtend/issues/643), applicable also to nxext for nx 14+, the capacitor plugin can try to use wrong `cap` executable since it cannot know which package this executable is referenced to. It happened in our project and tied to run `cap` package (capturing socket packages) which is the wrong executable.

So the solution is simply to add the `--package` option with `@capacitor/cli` package to ensure NPX will use the executable from proper package, as stated as per NPX docs.