### PR TITLE
refactor: migrate to `nx:run-commands`

### DIFF
--- a/packages/capacitor/src/executors/cap/executor.ts
+++ b/packages/capacitor/src/executors/cap/executor.ts
@@ -1,7 +1,7 @@
 import { ExecutorContext, normalizePath } from '@nrwl/devkit';
 import runCommands, {
   RunCommandsOptions,
-} from '@nrwl/workspace/src/executors/run-commands/run-commands.impl';
+} from 'nx/src/executors/run-commands/run-commands.impl';
 import { CommandExecutorSchema } from './schema';
 
 export default async function runExecutor(

--- a/packages/stencil/src/generators/storybook-configuration/generator.ts
+++ b/packages/stencil/src/generators/storybook-configuration/generator.ts
@@ -225,7 +225,7 @@ function addStorybookTask(
 ) {
   const projectConfig = readProjectConfiguration(tree, projectName);
   projectConfig.targets['storybook'] = {
-    executor: '@nrwl/workspace:run-commands',
+    executor: 'nx:run-commands',
     options: {
       commands: [
         `nx run ${projectName}:serve`,

--- a/packages/stencil/src/generators/storybook-configuration/generator.ts
+++ b/packages/stencil/src/generators/storybook-configuration/generator.ts
@@ -1,30 +1,30 @@
 import {
   convertNxGenerator,
   formatFiles,
+  generateFiles,
   GeneratorCallback,
+  getWorkspaceLayout,
   joinPathFragments,
   logger,
+  offsetFromRoot,
   readJson,
   readProjectConfiguration,
+  stripIndents,
   Tree,
   updateProjectConfiguration,
   writeJson,
-  generateFiles,
-  offsetFromRoot,
-  stripIndents,
-  getWorkspaceLayout,
 } from '@nrwl/devkit';
-import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 import { Linter } from '@nrwl/linter';
-import { join } from 'path';
 import { cypressProjectGenerator } from '@nrwl/storybook';
 import { initGenerator } from '@nrwl/storybook/src/generators/init/init';
 import { TsConfig } from '@nrwl/storybook/src/utils/utilities';
-import { StorybookConfigureSchema } from './schema';
-import { updateLintConfig } from './lib/update-lint-config';
-import { isBuildableStencilProject } from '../../utils/utillities';
+import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 import { getRootTsConfigPathInTree } from '@nrwl/workspace/src/utilities/typescript';
+import { join } from 'path';
+import { isBuildableStencilProject } from '../../utils/utillities';
 import { updateDependencies } from './lib/add-dependencies';
+import { updateLintConfig } from './lib/update-lint-config';
+import { StorybookConfigureSchema } from './schema';
 
 /**
  * With Nx `npmScope` (eg: nx-workspace) and `projectName` (eg: nx-project), returns a path portion to be used for import statements or

--- a/packages/svelte/src/generators/utils/targets.ts
+++ b/packages/svelte/src/generators/utils/targets.ts
@@ -1,6 +1,6 @@
 import { joinPathFragments, TargetConfiguration } from '@nrwl/devkit';
-import { NormalizedSchema as LibrarySchema } from '../library/schema';
 import { NormalizedSchema as ApplicationSchema } from '../application/schema';
+import { NormalizedSchema as LibrarySchema } from '../library/schema';
 
 export function createViteTargets(
   projectType: ProjectType,

--- a/packages/svelte/src/generators/utils/targets.ts
+++ b/packages/svelte/src/generators/utils/targets.ts
@@ -79,7 +79,7 @@ export function createSvelteCheckTarget(
   options: LibrarySchema | ApplicationSchema
 ): TargetConfiguration {
   return {
-    executor: '@nrwl/workspace:run-commands',
+    executor: 'nx:run-commands',
     options: {
       command: 'svelte-check',
       cwd: options.projectRoot,

--- a/packages/sveltekit/src/executors/add/executor.ts
+++ b/packages/sveltekit/src/executors/add/executor.ts
@@ -1,5 +1,3 @@
-import { AddExecutorSchema } from './schema';
-import { default as runCommands } from '@nrwl/workspace/src/executors/run-commands/run-commands.impl';
 import {
   ExecutorContext,
   getPackageManagerCommand,
@@ -7,7 +5,9 @@ import {
   readJsonFile,
   writeJsonFile,
 } from '@nrwl/devkit';
+import { default as runCommands } from '@nrwl/workspace/src/executors/run-commands/run-commands.impl';
 import { sortObjectByKeys } from '@nrwl/workspace/src/utils/ast-utils';
+import { AddExecutorSchema } from './schema';
 
 export default async function runExecutor(
   options: AddExecutorSchema,

--- a/packages/sveltekit/src/executors/add/executor.ts
+++ b/packages/sveltekit/src/executors/add/executor.ts
@@ -5,8 +5,8 @@ import {
   readJsonFile,
   writeJsonFile,
 } from '@nrwl/devkit';
-import { default as runCommands } from '@nrwl/workspace/src/executors/run-commands/run-commands.impl';
 import { sortObjectByKeys } from '@nrwl/workspace/src/utils/ast-utils';
+import { default as runCommands } from 'nx/src/executors/run-commands/run-commands.impl';
 import { AddExecutorSchema } from './schema';
 
 export default async function runExecutor(

--- a/packages/sveltekit/src/executors/sveltekit/executor.ts
+++ b/packages/sveltekit/src/executors/sveltekit/executor.ts
@@ -1,6 +1,6 @@
-import { SveltekitExecutorOptions } from './schema';
 import { ExecutorContext, joinPathFragments, logger } from '@nrwl/devkit';
 import { default as runCommands } from '@nrwl/workspace/src/executors/run-commands/run-commands.impl';
+import { SveltekitExecutorOptions } from './schema';
 
 export default async function runExecutor(
   options: SveltekitExecutorOptions,

--- a/packages/sveltekit/src/executors/sveltekit/executor.ts
+++ b/packages/sveltekit/src/executors/sveltekit/executor.ts
@@ -1,5 +1,5 @@
 import { ExecutorContext, joinPathFragments, logger } from '@nrwl/devkit';
-import { default as runCommands } from '@nrwl/workspace/src/executors/run-commands/run-commands.impl';
+import { default as runCommands } from 'nx/src/executors/run-commands/run-commands.impl';
 import { SveltekitExecutorOptions } from './schema';
 
 export default async function runExecutor(

--- a/packages/sveltekit/src/generators/application/lib/targets.ts
+++ b/packages/sveltekit/src/generators/application/lib/targets.ts
@@ -49,7 +49,7 @@ export function createSvelteCheckTarget(
   options: NormalizedSchema
 ): TargetConfiguration {
   return {
-    executor: '@nrwl/workspace:run-commands',
+    executor: 'nx:run-commands',
     options: {
       command: 'svelte-check',
       cwd: options.projectRoot,


### PR DESCRIPTION
The `@nrwl/workspace:run-commands` executor is deprecated and scheduled for removal in Nx 16. This executor is being moved to `nx:run-commands`.

Consumers of Nxext executor delegating to `@nrwl/workspace:run-commands` receive a deprecation warning about this when running `@nxext/capacitor:cap`.

Projects with targets generated by Nxext receive a deprecation warning about this when the generated targets use the `@nrwl/workspace:run-commands` generator.