### PR TITLE
chore(capacitor): use version ranges for dependencies

### DIFF
--- a/packages/capacitor/package.json
+++ b/packages/capacitor/package.json
@@ -25,10 +25,10 @@
     "migrations": "./migrations.json"
   },
   "dependencies": {
-    "@nrwl/devkit": "15.0.10"
+    "@nrwl/devkit": "^15.0.10"
   },
   "peerDependencies": {
-    "@nrwl/workspace": "15.0.10",
-    "nx": "15.0.10"
+    "@nrwl/workspace": "^15.0.10",
+    "nx": "^15.0.10"
   }
 }


### PR DESCRIPTION
This removes warnings for consumers using a version of Nx dependencies having the same major version.

Change based on the outcome of #841.