### PR TITLE
chore(capacitor): list `nx` as peer dependency

### DIFF
--- a/packages/capacitor/package.json
+++ b/packages/capacitor/package.json
@@ -28,6 +28,7 @@
     "@nrwl/devkit": "15.0.10"
   },
   "peerDependencies": {
-    "@nrwl/workspace": "15.0.10"
+    "@nrwl/workspace": "15.0.10",
+    "nx": "15.0.10"
   }
 }


### PR DESCRIPTION
`@nrwl/devkit` has a peer dependency on `nx` so we must specify `nx` in our (peer) dependencies.

Change based on the outcome of #839.