### PR TITLE
Update capacitor homepage & git repository

### DIFF
--- a/packages/capacitor/package.json
+++ b/packages/capacitor/package.json
@@ -6,10 +6,10 @@
     "name": "Devin Shoemaker",
     "email": "devinshoe@gmail.com"
   },
-  "homepage": "https://nxtend.dev/docs/capacitor/getting-started",
+  "homepage": "https://nxext.dev/docs/capacitor/getting-started.html",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nxtend-team/nxtend.git"
+    "url": "git+https://github.com/nxext/nx-extensions.git"
   },
   "license": "MIT",
   "main": "src/index.js",


### PR DESCRIPTION
## The problem

[NPM](https://www.npmjs.com/package/@nxext/capacitor) is pointing to the Nxtend homepage & git repository

## What's been done

- [x] Updated `homepage` and `git` repo in package.json