### PR TITLE
chore(repo): add packageManager info in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "prepare": "is-ci || husky install"
   },
   "private": true,
+  "packageManager": "yarn@1.22.19",
   "dependencies": {},
   "devDependencies": {
     "@nx/angular": "16.1.4",


### PR DESCRIPTION
Adding `packageManager` info in `package.json` so that this repo can work with nx-ecosystem-ci