### PR TITLE
Use execSync in capacitor executor

### DIFF
--- a/packages/capacitor/src/executors/cap/executor.ts
+++ b/packages/capacitor/src/executors/cap/executor.ts
@@ -57,13 +57,6 @@ export default async function* runExecutor(
 
   const cmd = sanitizeCapacitorCommand(options.cmd);
 
-  const runCommandsOptions: RunCommandsOptions = {
-    cwd: projectRootPath,
-    command: `npx --package=${packageName}@${packageVersion} cap ${cmd}`,
-    forwardAllArgs: true,
-    __unparsed__: [],
-  };
-
   let success = false
   try {
     execSync(`npx --package=${packageName}@${packageVersion} cap ${cmd}`, { cwd: projectRootPath })

--- a/packages/capacitor/src/executors/cap/executor.ts
+++ b/packages/capacitor/src/executors/cap/executor.ts
@@ -12,7 +12,7 @@ import runCommands, {
 } from 'nx/src/executors/run-commands/run-commands.impl';
 import { CommandExecutorSchema } from './schema';
 import { existsSync, rmSync } from 'fs';
-import { execSync } from 'node:child_process'
+import { execSync } from 'node:child_process';
 
 export default async function* runExecutor(
   options: CommandExecutorSchema,
@@ -57,11 +57,15 @@ export default async function* runExecutor(
 
   const cmd = sanitizeCapacitorCommand(options.cmd);
 
-  let success = false
+  let success = false;
   try {
-    execSync(`npx --package=${packageName}@${packageVersion} cap ${cmd}`, { cwd: projectRootPath })
-    success = true
-  } catch {}
+    execSync(`npx --package=${packageName}@${packageVersion} cap ${cmd}`, {
+      cwd: projectRootPath,
+    });
+    success = true;
+  } catch {
+    success = false;
+  }
 
   const nodeModulesPath = normalizePath(`${projectRootPath}/node_modules`);
   if (existsSync(nodeModulesPath) && !preserveProjectNodeModules) {

--- a/packages/capacitor/src/executors/cap/executor.ts
+++ b/packages/capacitor/src/executors/cap/executor.ts
@@ -12,6 +12,7 @@ import runCommands, {
 } from 'nx/src/executors/run-commands/run-commands.impl';
 import { CommandExecutorSchema } from './schema';
 import { existsSync, rmSync } from 'fs';
+import { execSync } from 'node:child_process'
 
 export default async function* runExecutor(
   options: CommandExecutorSchema,
@@ -63,7 +64,11 @@ export default async function* runExecutor(
     __unparsed__: [],
   };
 
-  const result = await runCommands(runCommandsOptions, context);
+  let success = false
+  try {
+    execSync(`npx --package=${packageName}@${packageVersion} cap ${cmd}`, { cwd: projectRootPath })
+    success = true
+  } catch {}
 
   const nodeModulesPath = normalizePath(`${projectRootPath}/node_modules`);
   if (existsSync(nodeModulesPath) && !preserveProjectNodeModules) {
@@ -75,7 +80,7 @@ export default async function* runExecutor(
     }
   }
 
-  return result;
+  return { success };
 }
 
 /**

--- a/packages/capacitor/src/executors/cap/executor.ts
+++ b/packages/capacitor/src/executors/cap/executor.ts
@@ -60,6 +60,7 @@ export default async function* runExecutor(
   let success = false;
   try {
     execSync(`npx --package=${packageName}@${packageVersion} cap ${cmd}`, {
+      stdio: 'inherit',
       cwd: projectRootPath,
     });
     success = true;


### PR DESCRIPTION
Using nxs implementation of runCommand inside the capacitor executor prevents the capacitor cli from being interactive

This PR uses execSync to execute the capacitor cli command

potentially fixes: #925