### PR TITLE
fix(stencil): update stencil peer dep to correct version

### DIFF
--- a/packages/stencil/package.json
+++ b/packages/stencil/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "@nxext/svelte": "^16.3.0",
-    "@stencil/core": "^2.17.1",
+    "@stencil/core": "^3.4.0",
     "@nx/workspace": "16.3.0",
     "@nx/linter": "16.3.0",
     "@nx/cypress": "16.3.0",


### PR DESCRIPTION
When I tried to install @nxext/stencil@16.3.0 it gave a peer dependency error as this hadn't been updated to 3.4.0.