### PR TITLE
fix: link to getting started in nx.dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Always run `yarn format` before doing a push!
 
 This project uses the Nx CLI with Yarn 1.x.
 
-This project is built with Nx and follows the OSS project structure. The [Getting Started](https://nx.dev/angular/getting-started/what-is-nx) guide shows how to work with Nx workspaces.
+This project is built with Nx and follows the OSS project structure. The [Getting Started](https://nx.dev/getting-started) guide shows how to work with Nx workspaces.
 
 ## Build
 


### PR DESCRIPTION
This fixes the link to NX's site for getting started.