### PR TITLE
Bugfix/fixed eslint prettier vue version

### DIFF
--- a/packages/nuxt/src/generators/utils/versions.ts
+++ b/packages/nuxt/src/generators/utils/versions.ts
@@ -7,5 +7,5 @@ export const vueTestUtilsVersion = '^2.4.1';
 export const nxextVueVersion = '^16.7.0';
 export const eslintPluginNuxtConfigTypescript = '^12.0.0';
 export const eslintPluginVueVersion = '^9.14.1';
-export const eslintPluginPrettierVueVersion = '^8.0.0';
+export const eslintPluginPrettierVueVersion = '^7.1.0';
 export const eslintPluginTypescriptVueVersion = '^11.0.3';

--- a/packages/vue/src/generators/utils/versions.ts
+++ b/packages/vue/src/generators/utils/versions.ts
@@ -4,5 +4,5 @@ export const vueRouterVersion = '^4.2.4';
 export const vitePluginVueVersion = '^4.3.1';
 export const vueTestUtilsVersion = '^2.4.1';
 export const eslintPluginVueVersion = '^9.14.1';
-export const eslintPluginPrettierVueVersion = '^8.0.0';
+export const eslintPluginPrettierVueVersion = '^7.1.0';
 export const eslintPluginTypescriptVueVersion = '^11.0.3';


### PR DESCRIPTION
There's a conflicting peer dependency with a newer Prettier version when using "@vue/eslint-config-prettier": "^8.0.0". In order to align with Nx Prettier version, we need to downgrade to 7.1.0