### PR TITLE
chore(docs): replace yarn references for pnpm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,11 @@
 
 PR's, ideas and discussions are welcome.
 
-Always run `yarn format` before doing a push!
+Always run `pnpm format` before doing a push!
 
 ## Project Structure
 
-This project uses the Nx CLI with Yarn 1.x.
+This project uses the Nx CLI with pnpm.
 
 This project is built with Nx and follows the OSS project structure. The [Getting Started](https://nx.dev/getting-started) guide shows how to work with Nx workspaces.
 
@@ -15,13 +15,13 @@ This project is built with Nx and follows the OSS project structure. The [Gettin
 After cloning the project, to install the dependencies, run:
 
 ```
-yarn
+pnpm install
 ```
 
 To build a plugin, run:
 
 ```
-yarn build [plugin]
+pnpm build [plugin]
 ```
 
 ## Run the Unit Tests
@@ -29,7 +29,7 @@ yarn build [plugin]
 Run unit tests for a specific plugin with:
 
 ```
-yarn test [plugin]
+pnpm test [plugin]
 ```
 
 ## Run the e2e Tests
@@ -37,7 +37,7 @@ yarn test [plugin]
 Run e2e tests for a specific plugin with:
 
 ```
-yarn e2e [plugin]
+pnpm e2e [plugin]
 ```
 
 ## Test Locally
@@ -45,7 +45,7 @@ yarn e2e [plugin]
 Create a playground Nx repository:
 
 ```
-yarn create-playground
+pnpm create-playground
 ```
 
 This will create a playground repository inside the Nxext repository directory. You'll find it here:
@@ -57,31 +57,7 @@ It is a regular Nx repository and you're able to do everything like create proje
 To update the playground with changes on the plugins without rebuilding a new playground, run:
 
 ```
-yarn update-playground
+pnpm update-playground
 ```
-
-## Publishing to a local registry
-
-To test if your changes will actually work once the changes are published,
-it can be useful to publish to a local registry.
-
-```bash
-# Starts the local registry. Keep this running in a separate terminal.
-yarn local-registry start
-
-# Set npm and yarn to use the local registry.
-# Note: This reroutes your installs to your local registry
-yarn local-registry enable
-
-# Revert npm and yarn to use their default registries
-yarn local-registry disable
-```
-
-To publish packages to a local registry, do the following:
-
-- Run `yarn local-registry start` in Terminal 1 (keep it running)
-- Run `npm adduser --registry http://localhost:4873` in Terminal 2 (real credentials are not required, you just need to be logged in. You can use test/test/test@test.io.)
-- Run `yarn local-registry enable` in Terminal 2
-- Run `yarn local-release 999.9.9` in Terminal 2
 
 **Happy coding :-)**

--- a/docs/docs/nxext/contributing.md
+++ b/docs/docs/nxext/contributing.md
@@ -4,7 +4,7 @@ PR's, ideas and discussions are welcome.
 
 ## Project Structure
 
-This project uses the Nx CLI with Yarn 1.x.
+This project uses the Nx CLI with pnpm.
 
 This project is built with Nx and follows the OSS project structure. The [Getting Started](https://nx.dev/angular/getting-started/what-is-nx) guide shows how to work with Nx workspaces.
 
@@ -13,13 +13,13 @@ This project is built with Nx and follows the OSS project structure. The [Gettin
 After cloning the project, to install the dependencies, run:
 
 ```
-yarn
+pnpm install
 ```
 
 To build a plugin, run:
 
 ```
-yarn build [plugin]
+pnpm build [plugin]
 ```
 
 ## Run the Unit Tests
@@ -27,7 +27,7 @@ yarn build [plugin]
 Run unit tests for a specific plugin with:
 
 ```
-yarn test [plugin]
+pnpm test [plugin]
 ```
 
 ## Run the e2e Tests
@@ -35,7 +35,7 @@ yarn test [plugin]
 Run e2e tests for a specific plugin with:
 
 ```
-yarn e2e [plugin]
+pnpm e2e [plugin]
 ```
 
 ## Test Locally
@@ -43,7 +43,7 @@ yarn e2e [plugin]
 Create a playground Nx repository:
 
 ```
-yarn create-playground
+pnpm create-playground
 ```
 
 This will create a playground repository inside the Nxext repository directory. You'll find it here:
@@ -55,31 +55,7 @@ It is a regular Nx repository and you're able to do everything like create proje
 To update the playground with changes on the plugins without rebuilding a new playground, run:
 
 ```
-yarn update-playground
+pnpm update-playground
 ```
-
-## Publishing to a local registry
-
-To test if your changes will actually work once the changes are published,
-it can be useful to publish to a local registry.
-
-```bash
-# Starts the local registry. Keep this running in a separate terminal.
-yarn local-registry start
-
-# Set npm and yarn to use the local registry.
-# Note: This reroutes your installs to your local registry
-yarn local-registry enable
-
-# Revert npm and yarn to use their default registries
-yarn local-registry disable
-```
-
-To publish packages to a local registry, do the following:
-
-- Run `yarn local-registry start` in Terminal 1 (keep it running)
-- Run `npm adduser --registry http://localhost:4873` in Terminal 2 (real credentials are not required, you just need to be logged in. You can use test/test/test@test.io.)
-- Run `yarn local-registry enable` in Terminal 2
-- Run `yarn local-release 999.9.9` in Terminal 2
 
 **Happy coding :-)**


### PR DESCRIPTION
Since pnpm is the package manager of this repository, it make sense to go ahead and update the references in the docs.
I removed the setting up a local registry as the commands for local-registry didn't exist. 
There are `start-local-registry` and `stop-local-registry` scripts, however those looks to be used mostly for pipeline testing. I think if we want repurpose that section to rely on those scripts I think that might be worth a follow up PR.