### PR TITLE
fix(solid): add missing vitest enum value to the library schema

### DIFF
--- a/packages/solid/src/generators/library/schema.json
+++ b/packages/solid/src/generators/library/schema.json
@@ -26,7 +26,7 @@
     },
     "unitTestRunner": {
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "description": "Test runner to use for unit tests.",
       "default": "jest"
     },


### PR DESCRIPTION
Vitest is a valid value for the unit test runner option, but it's missing from the schema file, therefore it's not possible to use it as NX validates the inputs against the schema.

This PR adds the vitest option to the schema.