### PR TITLE
update docs to include link to ionic

### DIFF
--- a/docs/docs/nxext/overview.md
+++ b/docs/docs/nxext/overview.md
@@ -4,15 +4,16 @@
 for [third-party plugins](https://nx.dev/nx-community) to add support for other
 technologies. [Nxext](https://github.com/nxext/nx-extensions) is a collection of plugins for an Nx workspace.
 
-| Package                                     | Description                                                                                     |
-| ------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [`@nxext/stencil`](../stencil/overview)     | An Nx plugin for development of [StencilJS](https://stenciljs.com/) applications and libraries. |
-| [`@nxext/svelte`](../svelte/overview)       | An Nx plugin for development of [Svelte](https://svelte.dev/) applications.                     |
-| [`@nxext/solid`](../solid/overview)         | An Nx plugin for development of [SolidJS](https://www.solidjs.com/) applications.               |
-| [`@nxext/vite`](../vite/overview)           | An Nx plugin for development with [Vite](https://vitejs.dev/).                                  |
-| [`@nxext/vitest`](../vitest/overview)       | An Nx plugin for development with [Vitest](https://vitest.dev/).                                |
-| [`@nxext/react`](../react/overview)         | An Nx plugin for development with [React](https://reactjs.org/).                                |
-| [`@nxext/preact`](../preact/overview)       | An Nx plugin for development with [Preact](https://reactjs.org/).                               |
-| [`@nxext/sveltekit`](../sveltekit/overview) | (Alpha) An NX plugin for development with [SvelteKit](https://kit.svelte.dev/) applications.    |
-| [`@nxext/vue`](../vue/overview)             | (Alpha) An NX plugin for development with [Vue](https://kit.svelte.dev/) applications.          |
-| [`@nxext/nuxt`](../nuxt/overview)           | (Alpha) An NX plugin for development with [Nuxt3](https://nuxt.com/) applications.              |
+| Package                                                                      | Description                                                                                     |
+| ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| [`@nxext/stencil`](../stencil/overview)                                      | An Nx plugin for development of [StencilJS](https://stenciljs.com/) applications and libraries. |
+| [`@nxext/svelte`](../svelte/overview)                                        | An Nx plugin for development of [Svelte](https://svelte.dev/) applications.                     |
+| [`@nxext/solid`](../solid/overview)                                          | An Nx plugin for development of [SolidJS](https://www.solidjs.com/) applications.               |
+| [`@nxext/vite`](../vite/overview)                                            | An Nx plugin for development with [Vite](https://vitejs.dev/).                                  |
+| [`@nxext/vitest`](../vitest/overview)                                        | An Nx plugin for development with [Vitest](https://vitest.dev/).                                |
+| [`@nxext/react`](../react/overview)                                          | An Nx plugin for development with [React](https://reactjs.org/).                                |
+| [`@nxext/preact`](../preact/overview)                                        | An Nx plugin for development with [Preact](https://reactjs.org/).                               |
+| [`@nxext/sveltekit`](../sveltekit/overview)                                  | (Alpha) An NX plugin for development with [SvelteKit](https://kit.svelte.dev/) applications.    |
+| [`@nxext/vue`](../vue/overview)                                              | (Alpha) An NX plugin for development with [Vue](https://kit.svelte.dev/) applications.          |
+| [`@nxext/nuxt`](../nuxt/overview)                                            | (Alpha) An NX plugin for development with [Nuxt3](https://nuxt.com/) applications.              |
+| [`@nxext/nx-extensions-ionic`](https://github.com/nxext/nx-extensions-ionic) | Nx extensions for [Ionic](https://ionic.io) applications                                        |

--- a/docs/docs/nxext/overview.md
+++ b/docs/docs/nxext/overview.md
@@ -13,7 +13,7 @@ technologies. [Nxext](https://github.com/nxext/nx-extensions) is a collection of
 | [`@nxext/vitest`](../vitest/overview)                                        | An Nx plugin for development with [Vitest](https://vitest.dev/).                                |
 | [`@nxext/react`](../react/overview)                                          | An Nx plugin for development with [React](https://reactjs.org/).                                |
 | [`@nxext/preact`](../preact/overview)                                        | An Nx plugin for development with [Preact](https://reactjs.org/).                               |
+| [`@nxext/nx-extensions-ionic`](https://github.com/nxext/nx-extensions-ionic) | Nx plugins for [Ionic](https://ionic.io) applications                                           |
 | [`@nxext/sveltekit`](../sveltekit/overview)                                  | (Alpha) An NX plugin for development with [SvelteKit](https://kit.svelte.dev/) applications.    |
 | [`@nxext/vue`](../vue/overview)                                              | (Alpha) An NX plugin for development with [Vue](https://kit.svelte.dev/) applications.          |
 | [`@nxext/nuxt`](../nuxt/overview)                                            | (Alpha) An NX plugin for development with [Nuxt3](https://nuxt.com/) applications.              |
-| [`@nxext/nx-extensions-ionic`](https://github.com/nxext/nx-extensions-ionic) | Nx extensions for [Ionic](https://ionic.io) applications                                        |

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,4 +32,6 @@ features:
     details: An approachable, performant and versatile framework for building web user interfaces.
   - title: Nuxt (Alpha)
     details: The Intuitive Web Framework
+  - title: Ionic
+    details: A new way to build and ship for mobile.
 ---


### PR DESCRIPTION
This PR is to add the Github link to the `@nxext/nx-extensions-ionic`.  If it is better, I can move the .md files for ionic-angular and ionic-react to this repo instead.