### PR TITLE
chore(stencil): Don't copy the packageJson when specified distDir is same as projectRoot

### DIFF
--- a/packages/stencil/src/executors/stencil-runtime/prepare-config-and-outputarget-paths.ts
+++ b/packages/stencil/src/executors/stencil-runtime/prepare-config-and-outputarget-paths.ts
@@ -26,7 +26,9 @@ function copyOrCreatePackageJson(pathCollection: PathCollection) {
   };
 
   if (fileExists(pathCollection.pkgJson)) {
-    copyFile(pathCollection.pkgJson, pathCollection.distDir);
+    if (pathCollection.projectRoot !== pathCollection.distDir) {
+      copyFile(pathCollection.pkgJson, pathCollection.distDir);
+    }
   } else {
     writeJsonFile(
       joinPathFragments(pathCollection.distDir, 'package.json'),


### PR DESCRIPTION
Small refactor to cover an edge case when specified projectRoot and distDir are the same, best not to update `package.json` file 