### PR TITLE
fix(stencil): Don't look for dependencies build status on same targetName when dependsOn is specified

### DIFF
--- a/packages/stencil/src/executors/build/executor.ts
+++ b/packages/stencil/src/executors/build/executor.ts
@@ -54,6 +54,7 @@ export default async function runExecutor(
   );
 
   if (
+    !context.target.dependsOn &&
     !checkDependentProjectsHaveBeenBuilt(
       context.root,
       context.projectName,


### PR DESCRIPTION
No need to check for dep build status on same targetName when explicit `dependsOn` is specified 