### PR TITLE
fix(stencil): Resolve exception when adding Angular output target (#1065)

### DIFF
--- a/packages/stencil/src/stencil-core-utils/lib/plugins.ts
+++ b/packages/stencil/src/stencil-core-utils/lib/plugins.ts
@@ -15,20 +15,20 @@ function addCodeIntoArray(
 ): StringChange[] {
   const nodes = findNodes(source, ts.SyntaxKind.ObjectLiteralExpression);
   let node = nodes[0];
-  const matchingProperties: ts.ObjectLiteralElement[] = node && (
-    node as ts.ObjectLiteralExpression
-  ).properties
-    .filter(
-      (prop: ts.ObjectLiteralElementLike) =>
-        prop.kind == ts.SyntaxKind.PropertyAssignment
-    )
-    .filter((prop: ts.PropertyAssignment) => {
-      if (prop.name.kind === ts.SyntaxKind.Identifier) {
-        return (prop.name as ts.Identifier).getText(source) == identifier;
-      }
+  const matchingProperties: ts.ObjectLiteralElement[] =
+    node &&
+    (node as ts.ObjectLiteralExpression).properties
+      .filter(
+        (prop: ts.ObjectLiteralElementLike) =>
+          prop.kind == ts.SyntaxKind.PropertyAssignment
+      )
+      .filter((prop: ts.PropertyAssignment) => {
+        if (prop.name.kind === ts.SyntaxKind.Identifier) {
+          return (prop.name as ts.Identifier).getText(source) == identifier;
+        }
 
-      return false;
-    });
+        return false;
+      });
 
   if (!matchingProperties) {
     return [];

--- a/packages/stencil/src/stencil-core-utils/lib/plugins.ts
+++ b/packages/stencil/src/stencil-core-utils/lib/plugins.ts
@@ -15,7 +15,7 @@ function addCodeIntoArray(
 ): StringChange[] {
   const nodes = findNodes(source, ts.SyntaxKind.ObjectLiteralExpression);
   let node = nodes[0];
-  const matchingProperties: ts.ObjectLiteralElement[] = (
+  const matchingProperties: ts.ObjectLiteralElement[] = node && (
     node as ts.ObjectLiteralExpression
   ).properties
     .filter(


### PR DESCRIPTION
* Addressed critical exception preventing Buildable Angular/React integrations with Stencil.