### PR TITLE
fix(stencil): resolve `validateConfig` error from @stencil/core@14.17.0 onward.

### DIFF
--- a/packages/stencil/src/executors/stencil-runtime/stencil-process.spec.ts
+++ b/packages/stencil/src/executors/stencil-runtime/stencil-process.spec.ts
@@ -1,0 +1,25 @@
+import { CompilerSystem, createNodeSys } from '@stencil/core/sys/node';
+
+import { loadCoreCompiler } from './stencil-process';
+
+function getCompilerExecutingPath(): string {
+  return require.resolve('@stencil/core/compiler');
+}
+
+describe('process', () => {
+  describe('loadCoreCompiler', () => {
+    it('should return globalThis.stencil', async () => {
+      const sys: CompilerSystem = createNodeSys({ process });
+
+      if (sys.getCompilerExecutingPath == null) {
+        sys.getCompilerExecutingPath = getCompilerExecutingPath;
+      }
+
+      expect(globalThis.stencil).toBeUndefined();
+
+      await loadCoreCompiler(sys);
+
+      expect(globalThis.stencil).toBeTruthy();
+    });
+  });
+});

--- a/packages/stencil/src/executors/stencil-runtime/stencil-process.ts
+++ b/packages/stencil/src/executors/stencil-runtime/stencil-process.ts
@@ -7,9 +7,15 @@ type CoreCompiler = typeof import('@stencil/core/compiler');
 export const loadCoreCompiler = async (
   sys: CompilerSystem
 ): Promise<CoreCompiler> => {
-  await sys.dynamicImport(sys.getCompilerExecutingPath());
+  const coreCompiler: CoreCompiler = await sys.dynamicImport(
+    sys.getCompilerExecutingPath()
+  );
 
-  return (globalThis as any).stencil;
+  if (!('stencil' in globalThis)) {
+    globalThis.stencil = coreCompiler;
+  }
+
+  return globalThis.stencil;
 };
 
 export async function createStencilProcess(config: Config): Promise<void> {


### PR DESCRIPTION
Hey!

From @stencil/core@14.17.0 onward, the following error occurs for executors 'build', 'test', 'e2e', and 'serve': `Cannot read properties of undefined (reading 'validateConfig')`.

This issue stems from `globalThis.stencil` not being properly set within the `loadCoreCompiler` function.

To resolve this, the `loadCoreCompiler` function has been updated to ensure proper initialization of `globalThis.stencil` by assigning the imported compiler module if `globalThis.stencil` is undefined.

Additionally, I have added a test case in `stencil-process.spec.ts` to validate the correct initialization of `globalThis.stencil` by `loadCoreCompiler`.

I have tested the fix by upgrading the '@stencil/core' package from version 4.12.6 to 4.17.0 within this repo and running the tests in `stencil-process.spec.ts` with and without the fix applied.

This issue has also been mentioned in #1086 