### PR TITLE
docs(nxext): update nx-community link

### DIFF
--- a/docs/docs/nxext/overview.md
+++ b/docs/docs/nxext/overview.md
@@ -1,7 +1,7 @@
 # Overview
 
 [Nx](https://nx.dev/) is a set of extensible dev tools for monorepos and allows
-for [third-party plugins](https://nx.dev/nx-community) to add support for other
+for [third-party plugins](https://nx.dev/community) to add support for other
 technologies. [Nxext](https://github.com/nxext/nx-extensions) is a collection of plugins for an Nx workspace.
 
 | Package                                                                      | Description                                                                                     |

--- a/docs/docs/vite/overview.md
+++ b/docs/docs/vite/overview.md
@@ -5,7 +5,7 @@
 We at Nxext believe the key to productivity is faster builds. [Nrwl NX](https://nx.dev) has done an amazing job with the enterprise-level monorepo. However, the crocks are still tied in [Angular](https://angular.io) and as a result [Webpack](https://webpack.js.org/). So we've turned to [Vite](https://vitejs.dev/) a build system that's bother quicker and smaller bundles.
 
 ::: danger
-The @nxext/vite package will be deprecated soon in favor of the new œnrwl/vite package
+The @nxext/vite package will be deprecated soon in favor of the new @nx/vite package
 :::
 
 ## Adding Vite builds

--- a/docs/docs/vitest/overview.md
+++ b/docs/docs/vitest/overview.md
@@ -3,5 +3,5 @@
 [@nxext/vitest](https://github.com/nxext/nx-extensions/tree/main/packages/vitest) is a nx plugin to bring [Vitest](https://vitest.dev) to [Nx](https://nx.dev/).
 
 ::: danger
-The @nxext/vitest package will be deprecated soon in favor of the new œnrwl/vite package
+The @nxext/vitest package will be deprecated soon in favor of the new @nx/vite package
 :::


### PR DESCRIPTION
https://nx.dev/nx-community is looks moved to https://nx.dev/community

And some minor updates.