### PR TITLE
fix(stencil): support Nx `context.projectsConfigurations`

### DIFF
--- a/packages/stencil/src/executors/stencil-runtime/stencil-config.ts
+++ b/packages/stencil/src/executors/stencil-runtime/stencil-config.ts
@@ -44,7 +44,10 @@ export async function initializeStencilConfig<
     logger.enableColors(false);
   }
 
-  const projectDir = context.workspace.projects[context.projectName].root;
+  const projects = context.workspace
+    ? context.workspace.projects
+    : context.projectsConfigurations.projects;
+  const projectDir = projects[context.projectName].root;
   const projectRoot = normalizePath(join(context.root, projectDir));
   const distDir = normalizePath(join(context.root, options.outputPath));
   const configPath = normalizePath(join(context.root, options.configPath));

--- a/packages/stencil/src/executors/stencil-runtime/stencil-config.ts
+++ b/packages/stencil/src/executors/stencil-runtime/stencil-config.ts
@@ -44,7 +44,8 @@ export async function initializeStencilConfig<
     logger.enableColors(false);
   }
 
-  const projectDir = context.projectsConfigurations.projects[context.projectName].root;
+  const projectDir =
+    context.projectsConfigurations.projects[context.projectName].root;
   const projectRoot = normalizePath(join(context.root, projectDir));
   const distDir = normalizePath(join(context.root, options.outputPath));
   const configPath = normalizePath(join(context.root, options.configPath));

--- a/packages/stencil/src/executors/stencil-runtime/stencil-config.ts
+++ b/packages/stencil/src/executors/stencil-runtime/stencil-config.ts
@@ -44,10 +44,7 @@ export async function initializeStencilConfig<
     logger.enableColors(false);
   }
 
-  const projects = context.workspace
-    ? context.workspace.projects
-    : context.projectsConfigurations.projects;
-  const projectDir = projects[context.projectName].root;
+  const projectDir = context.projectsConfigurations.projects[context.projectName].root;
   const projectRoot = normalizePath(join(context.root, projectDir));
   const distDir = normalizePath(join(context.root, options.outputPath));
   const configPath = normalizePath(join(context.root, options.configPath));


### PR DESCRIPTION
## Reason:

`context.workspace` field is deprecated since Nx@17 and seems to be removed in Nx@20; `context.projectsConfigurations` and be used instead.

This change makes **@nxext/stencil** compatible with Nx@20 without breaking compatibility with previous versions.