### PR TITLE
feat(docs/index): links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,16 +18,23 @@ hero:
 features:
   - title: Stencil
     details: Stencil is a library for building reusable, scalable component libraries. Generate small, blazing fast Web Components that run everywhere.
+    link: /docs/stencil/overview.html
   - title: Svelte
     details: Svelte is a radical new approach to building user interfaces. Whereas traditional frameworks like React and Vue do the bulk of their work in the browser, Svelte shifts that work into a compile step that happens when you build your app.
+    link: /docs/svelte/overview.html
   - title: SvelteKit
     details: SvelteKit is built on Svelte, a UI framework that uses a compiler to let you write breathtakingly concise components that do minimal work in the browser, using languages you already know — HTML, CSS and JavaScript.
+    link: /docs/sveltekit/overview.html
   - title: SolidJS
+    link: /docs/solid/overview.html
     details: Simple and performant reactivity for building user interfaces.
   - title: Preact
     details: Fast 3kB alternative to React with the same modern API.
+    link: /docs/preact/overview.html
   - title: Ionic
     details: A new way to build and ship for mobile.
+    link: /docs/ionic-angular/installation.html
   - title: Capacitor
     details: A cross-platform native runtime for web apps.
+    link: /docs/capacitor/generators.html
 ---

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "nx": "nx",
     "start": "nx serve",
+    "start:docs": "nx serve docs",
     "build": "nx build",
     "test": "nx test",
     "lint": "nx lint",


### PR DESCRIPTION
## Description
- Link main element to make them clickable to the start of their docs. 
- Add a new `start:docs` script, to let new contributor understand how to run the doc locally

### Pro
Lower the amount of click needed to find what we want's : )

### Screenshot
![image](https://github.com/user-attachments/assets/c0a4ede0-a534-4167-94e1-ed154f947b46)
