### PR TITLE
Solid: Some fixes for library and component generation. Fix for playground initialisation.

### DIFF
--- a/packages/solid/src/generators/component/component.spec.ts
+++ b/packages/solid/src/generators/component/component.spec.ts
@@ -38,7 +38,7 @@ describe('component schematic', () => {
 
     const indexFile = tree.read(`${projectLibDirectory}/src/index.ts`);
     expect(indexFile.toString('utf-8')).toMatch(
-      `export { default as ${name.className} } from './components/${name.fileName}/${name.className}.ts';`
+      `export { default as ${name.className} } from './components/${name.fileName}/${name.className}';`
     );
   });
 });

--- a/packages/solid/src/generators/component/lib/add-exports-to-barrel.ts
+++ b/packages/solid/src/generators/component/lib/add-exports-to-barrel.ts
@@ -17,7 +17,7 @@ export function addExportsToBarrel(tree: Tree, options: SolidComponentSchema) {
 
   const { className, fileName } = names(options.name);
   const indexFilePath = joinPathFragments(projectConfig.sourceRoot, 'index.ts');
-  const componentFile = `./components/${fileName}/${className}.ts`;
+  const componentFile = `./components/${fileName}/${className}`;
 
   if (projectConfig.projectType === 'library') {
     const { content, source } = readSourceFile(tree, indexFilePath);

--- a/packages/solid/src/generators/library/lib/update-tsconfig.ts
+++ b/packages/solid/src/generators/library/lib/update-tsconfig.ts
@@ -7,7 +7,6 @@ import {
 } from '@nx/devkit';
 
 export function updateTsConfig(tree: Tree, options: NormalizedSchema) {
-  const { libsDir } = getWorkspaceLayout(tree);
 
   return updateJson(tree, 'tsconfig.base.json', (json) => {
     const c = json.compilerOptions;
@@ -21,7 +20,7 @@ export function updateTsConfig(tree: Tree, options: NormalizedSchema) {
     }
 
     c.paths[options.importPath] = [
-      joinPathFragments(`${libsDir}/${options.projectDirectory}/src/index.ts`),
+      joinPathFragments(`${options.projectDirectory}/src/index.ts`),
     ];
     return json;
   });

--- a/tools/scripts/create-playground.ts
+++ b/tools/scripts/create-playground.ts
@@ -34,7 +34,7 @@ const baseName = basename(tmpProjPath());
 
 logger.info('Creating nx workspace...');
 execSync(
-  `npx --yes create-nx-workspace@latest ${baseName} --preset empty --nxCloud skip --no-interactive`,
+  `npx --yes create-nx-workspace@latest ${baseName} --preset apps --nxCloud skip --no-interactive`,
   {
     cwd: localTmpDir,
     stdio: 'inherit',


### PR DESCRIPTION
#1161
Removes an extra `libs` in the path when updating tsconfig.base.json. The path to the project  can be handled by the options.projectDirectory as is. 

```shell
nx g @nxext/solid:lib hello --directory packages/hello
nx g @nxext/solid:lib libs/world
cat tsconfig.base.json
...
"paths": {
      "@proj/hello": ["packages/hello/src/index.ts"],
      "@proj/world": ["libs/world/src/index.ts"]
    }
...
```

#1162
TS extension in component export causes  issues as we don't have `allowImportingTsExtensions`. Removing it works as expected.

---
Misc
Playground error when trying to set up development enviroment. There is no longer a preset empty it seems. nx20 broke a few things in that regard when moving to the new workspace model I think.

```
NX   Unable to resolve empty:preset.
The "empty" package does not support Nx generators.
```

