### PR TITLE
fix(Stencil): ensure `strictConfig` properties has default values if `loadedConfig` is undefined

### DIFF
--- a/packages/stencil/src/executors/stencil-runtime/stencil-config.ts
+++ b/packages/stencil/src/executors/stencil-runtime/stencil-config.ts
@@ -72,10 +72,10 @@ export async function initializeStencilConfig<
     ...loadedConfig,
     flags: flags,
     logger,
-    outputTargets: loadedConfig.outputTargets ?? [],
-    rootDir: loadedConfig.rootDir ?? '/',
-    sys: sys ?? loadedConfig.sys,
-    testing: loadedConfig.testing ?? {},
+    outputTargets: loadedConfig?.outputTargets ?? [],
+    rootDir: loadedConfig?.rootDir ?? '/',
+    sys: sys ?? loadedConfig?.sys,
+    testing: loadedConfig?.testing ?? {},
   };
 
   if (strictConfig.flags.task === 'build') {


### PR DESCRIPTION
The change ensures that the `strictConfig` object properties have default values if not provided in the `loadedConfig` or if `loadedConfig` is undefined.

When looking at the code, `const loadedConfig = loadConfigResults.config` where `loadConfigResults` results from an attempt to load a config:

```ts
const loadConfigResults = await loadConfig({
  config,
  configPath,
  logger,
  sys,
});
const loadedConfig = loadConfigResults.config;
```

meaning, perhaps, it could not be loaded at a certain point (_according to the `LoadConfigResults` interface declaration on `@stencil/core`_)

```ts
/**
 * Results from an attempt to load a config. The values on this interface
 * have not yet been validated and are not ready to be used for arbitrary
 * operations around the codebase.
 */
export interface LoadConfigResults {
    config: ValidatedConfig;
    diagnostics: Diagnostic[];
    tsconfig: {
        path: string;
        compilerOptions: any;
        files: string[];
        include: string[];
        exclude: string[];
        extends: string;
    };
}
```

Fixes: #1167