### PR TITLE
docs(config.mts): direct link to edit & GitHub

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -16,6 +16,19 @@ export default defineConfig({
       '/docs/': sideNavDocs(),
     },
 
+    editLink: {
+      pattern: 'https://github.com/nxext/nx-extensions/tree/main/docs/:path',
+      text: 'Edit this page on GitHub',
+    },
+
+    socialLinks: [
+      {
+        icon: 'discord',
+        link: 'https://discord.gg/SWyp4xfGjn',
+      },
+      { icon: 'github', link: 'https://github.com/nxext/nx-extensions' },
+    ],
+
     footer: {
       message:
         'MIT Licensed | Copyright © 2020-present Nxext Developers & Contributors',
@@ -29,19 +42,6 @@ function nav() {
   return [
     { text: 'Guide', link: '/guide/' },
     { text: 'Docs', link: '/docs/nxext/overview' },
-    {
-      text: 'Links',
-      items: [
-        {
-          text: 'Nx Discord Chat',
-          link: 'https://discord.gg/SWyp4xfGjn',
-        },
-        {
-          text: 'Github',
-          link: 'https://github.com/nxext/nx-extensions',
-        },
-      ],
-    },
   ];
 }
 


### PR DESCRIPTION
## Description
Uses latest vitepress logic for Social links & Edition

## Visual impacts 
- Smaller space being used in the header & faster to action : 

### before
<img width="392" height="174" alt="image" src="https://github.com/user-attachments/assets/5445cf85-9611-4c5e-a3e7-92833a5fe11c" />  

### After  
<img width="374" height="72" alt="image" src="https://github.com/user-attachments/assets/47500a56-7c49-4391-9c89-e8a6304f2fa9" />



- Being able to directly edit a page, at the bottom of it for easier docs maintenance
<img width="1164" height="688" alt="image" src="https://github.com/user-attachments/assets/81b3abbb-6631-43e9-8927-8f1ee670638e" />
