### PR TITLE
docs: update common/package.json to declare MIT license

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@nxext/common",
   "version": "21.0.0",
+  "license": "MIT",
   "description": "Common utilities for Nxext Nx plugins",
   "author": {
     "name": "Gion Kunz",


### PR DESCRIPTION
### Description

Declare the license (MIT) in `common/package.json` in the standard machine-readable way.

### Rationale

Currently, automated due diligence tools like `license-checker` cannot tell that `@nxext/common` is licensed under the MIT license, despite the fact that the GitHub repo clearly states it is so.

This license declaration in the sub-package will fix that.

Other sub-packages already have this declaration, only `common` is missing it.