### PR TITLE
feat(stencil): adopt Project Crystal for inferred tasks

### DIFF
--- a/e2e/stencil-e2e/tests/library.test.ts
+++ b/e2e/stencil-e2e/tests/library.test.ts
@@ -78,12 +78,12 @@ describe('@nxext/stencil: library', () => {
 
       const build = await runNxCommandAsync(
         projectDirectory,
-        `build ${lib} --configPath=libs/${lib}/${renamed}.ts`
+        `build ${lib} --config=${renamed}.ts`
       );
       expect(build.stdout).toContain('build finished');
     });
 
-    it('honors an explicit --configPath', async () => {
+    it('honors an explicit --config', async () => {
       const lib = uniq('stencil-lib');
       await runNxCommandAsync(
         projectDirectory,
@@ -92,7 +92,7 @@ describe('@nxext/stencil: library', () => {
 
       const build = await runNxCommandAsync(
         projectDirectory,
-        `build ${lib} --configPath=libs/${lib}/stencil.config.ts`
+        `build ${lib} --config=stencil.config.ts`
       );
       expect(build.stdout).toContain('build finished');
     });

--- a/packages/stencil/package.json
+++ b/packages/stencil/package.json
@@ -21,6 +21,11 @@
     "url": "https://github.com/nxext/nx-extensions/issues"
   },
   "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./package.json": "./package.json",
+    "./plugin": "./src/plugins/plugin.js"
+  },
   "schematics": "./generators.json",
   "generators": "./generators.json",
   "builders": "./executors.json",

--- a/packages/stencil/src/generators/add-outputtarget/add-outputtarget.ts
+++ b/packages/stencil/src/generators/add-outputtarget/add-outputtarget.ts
@@ -22,7 +22,7 @@ export async function outputtargetGenerator(
   const projectConfig = readProjectConfiguration(host, options.projectName);
   const tasks = [];
 
-  if (isBuildableStencilProject(projectConfig)) {
+  if (isBuildableStencilProject(projectConfig, host)) {
     if (options.outputType === 'angular') {
       tasks.push(await addAngularGenerator(host, options));
     }

--- a/packages/stencil/src/generators/init/init.spec.ts
+++ b/packages/stencil/src/generators/init/init.spec.ts
@@ -29,4 +29,14 @@ describe('init', () => {
     expect(packageJson.devDependencies['@stencil/router']).toBeDefined();
     expect(packageJson.devDependencies['@ionic/core']).toBeUndefined();
   });
+
+  it('registers @nxext/stencil/plugin in nx.json so Crystal can infer tasks', async () => {
+    await initGenerator(host, { name: 'test', appType: AppType.library });
+
+    const nxJson = readJson(host, 'nx.json');
+    const pluginNames = (nxJson.plugins ?? []).map(
+      (p: string | { plugin: string }) => (typeof p === 'string' ? p : p.plugin)
+    );
+    expect(pluginNames).toContain('@nxext/stencil/plugin');
+  });
 });

--- a/packages/stencil/src/generators/init/init.ts
+++ b/packages/stencil/src/generators/init/init.ts
@@ -6,6 +6,7 @@ import { formatFiles, Tree } from '@nx/devkit';
 import { runTasksInSerial } from '@nx/devkit';
 import { addCypress } from './lib/add-cypress';
 import { addJest } from './lib/add-jest';
+import { addPluginToNxJson } from '@nxext/common';
 import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 export async function initGenerator<T extends InitSchema>(
@@ -19,6 +20,8 @@ export async function initGenerator<T extends InitSchema>(
   const addPuppeteerTask = await addPuppeteer(host, options);
   const addCypressTask = await addCypress(host, options);
   const jestInitTask = await addJest(host, options);
+
+  addPluginToNxJson('@nxext/stencil/plugin', host);
 
   if (!options.skipFormat) {
     await formatFiles(host);

--- a/packages/stencil/src/generators/library/files/lib/tsconfig.json.template
+++ b/packages/stencil/src/generators/library/files/lib/tsconfig.json.template
@@ -17,6 +17,7 @@
     "jsx": "react",
     "jsxFactory": "h"
   },
+  "include": [],
   "references": [
     {
       "path": "./tsconfig.lib.json"

--- a/packages/stencil/src/generators/library/generator.spec.ts
+++ b/packages/stencil/src/generators/library/generator.spec.ts
@@ -171,13 +171,10 @@ describe('library', () => {
       [SupportedStyles.scss]: 'sass',
     };
 
-    it('should create build targets', async () => {
+    it('emits a stencil.config.ts so the Crystal plugin infers build targets', async () => {
       await libraryGenerator(host, options);
 
-      const projectConfig = readProjectConfiguration(host, options.name);
-      expect(projectConfig.targets['build']).toBeDefined();
-      expect(projectConfig.targets['e2e']).toBeDefined();
-      expect(projectConfig.targets['serve']).toBeDefined();
+      expect(host.exists('libs/testlib/stencil.config.ts')).toBeTruthy();
     });
 
     it('should export bundle', async () => {
@@ -233,13 +230,10 @@ describe('library', () => {
       }
     });
 
-    it('should create build targets', async () => {
+    it('emits a stencil.config.ts so the Crystal plugin infers build targets', async () => {
       await libraryGenerator(host, options);
 
-      const projectConfig = readProjectConfiguration(host, options.name);
-      expect(projectConfig.targets['build']).toBeDefined();
-      expect(projectConfig.targets['e2e']).toBeDefined();
-      expect(projectConfig.targets['serve']).toBeDefined();
+      expect(host.exists('libs/testlib/stencil.config.ts')).toBeTruthy();
     });
 
     it('should export bundle', async () => {

--- a/packages/stencil/src/generators/library/lib/add-project.ts
+++ b/packages/stencil/src/generators/library/lib/add-project.ts
@@ -1,12 +1,11 @@
 import { addProjectConfiguration, Tree } from '@nx/devkit';
-import { getTestTarget } from '../../../utils/targets';
 import { LibrarySchema } from '../schema';
 
 export function addProject(tree: Tree, options: LibrarySchema) {
-  const targets = {
-    test: getTestTarget('library', options),
-  };
-
+  // `test` (and `build`/`serve`/`e2e` for buildable libs) is inferred by
+  // `@nxext/stencil/plugin` from the presence of `stencil.config.ts`. Plain
+  // libraries without a stencil config get no runtime targets here — just
+  // project metadata.
   addProjectConfiguration(tree, options.name, {
     root: options.projectRoot,
     sourceRoot: `${options.projectRoot}/src`,
@@ -17,6 +16,6 @@ export function addProject(tree: Tree, options: LibrarySchema) {
       },
     },
     tags: options.parsedTags,
-    targets,
+    targets: {},
   });
 }

--- a/packages/stencil/src/generators/make-lib-buildable/make-lib-buildable.ts
+++ b/packages/stencil/src/generators/make-lib-buildable/make-lib-buildable.ts
@@ -10,13 +10,7 @@ import { MakeLibBuildableSchema } from './schema';
 import { addStylePluginToConfig } from '../../stencil-core-utils';
 import { addToOutputTargets } from '../../stencil-core-utils';
 import { updateTsConfig } from './lib/update-tsconfig';
-import {
-  getBuildTarget,
-  getE2eTarget,
-  getLintTarget,
-  getServeTarget,
-} from '../../utils/targets';
-import { AppType } from '../../utils/typings';
+import { getLintTarget } from '../../utils/targets';
 import { getProjectTsImportPath } from '../storybook-configuration/generator';
 import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
@@ -45,13 +39,9 @@ function updateProjectConfig(host: Tree, options: MakeLibBuildableSchema) {
   const projectConfig = readProjectConfiguration(host, options.name);
 
   projectConfig.targets = projectConfig.targets || {};
-  projectConfig.targets.build = getBuildTarget(AppType.library, options);
-  projectConfig.targets.serve = getServeTarget(AppType.library, options);
-  projectConfig.targets.e2e = getE2eTarget(AppType.library, options);
-  projectConfig.targets.lint = getLintTarget(
-    AppType.library,
-    options.projectRoot
-  );
+  // `build` / `serve` / `e2e` are inferred by `@nxext/stencil/plugin` once the
+  // new `stencil.config.ts` (written below in createFiles) is on disk.
+  projectConfig.targets.lint = getLintTarget(options.projectRoot);
 
   updateProjectConfiguration(host, options.name, projectConfig);
 }

--- a/packages/stencil/src/generators/storybook-configuration/generator.ts
+++ b/packages/stencil/src/generators/storybook-configuration/generator.ts
@@ -56,7 +56,7 @@ export async function storybookConfigurationGenerator(
 
   const projectConfig = readProjectConfiguration(host, options.name);
 
-  if (!isBuildableStencilProject(projectConfig)) {
+  if (!isBuildableStencilProject(projectConfig, host)) {
     logger.info(stripIndents`
       Please use a buildable library for storybook. Storybook needs a generated
       Stencil loader to work (yet). They're working on native Stencil support, but

--- a/packages/stencil/src/plugins/plugin.spec.ts
+++ b/packages/stencil/src/plugins/plugin.spec.ts
@@ -1,0 +1,128 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createNodesV2 } from './plugin';
+
+describe('@nxext/stencil/plugin', () => {
+  let workspaceRoot: string;
+
+  beforeEach(() => {
+    workspaceRoot = mkdtempSync(join(tmpdir(), 'nxext-stencil-plugin-'));
+  });
+
+  afterEach(() => {
+    rmSync(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it('infers build/serve/test/e2e for a project with stencil.config.ts', async () => {
+    const projectRoot = 'libs/my-stencil-lib';
+    scaffoldStencilProject(workspaceRoot, projectRoot);
+
+    const [_pattern, createNodesFn] = createNodesV2;
+    const results = await createNodesFn(
+      [`${projectRoot}/stencil.config.ts`],
+      {},
+      fakeContext(workspaceRoot)
+    );
+
+    expect(results).toHaveLength(1);
+    const [, result] = results[0];
+    const project = result.projects[projectRoot];
+
+    expect(project.metadata).toEqual({ technologies: ['stencil'] });
+
+    const targets = project.targets;
+    expect(targets.build).toMatchObject({
+      command: 'stencil build',
+      cache: true,
+      inputs: ['default', '^production'],
+      options: { cwd: projectRoot },
+    });
+    expect(targets.build.outputs).toContain(
+      `{workspaceRoot}/dist/${projectRoot}`
+    );
+
+    expect(targets.serve).toMatchObject({
+      command: 'stencil build --dev --watch --serve',
+      cache: false,
+      options: { cwd: projectRoot },
+    });
+
+    expect(targets.test).toMatchObject({
+      command: 'stencil test --spec',
+      cache: true,
+      inputs: ['default', '^production'],
+      options: { cwd: projectRoot },
+    });
+
+    expect(targets.e2e).toMatchObject({
+      command: 'stencil test --e2e',
+      cache: false,
+      options: { cwd: projectRoot },
+    });
+  });
+
+  it('skips config files that live outside of a project (no project.json / package.json next to them)', async () => {
+    const orphanRoot = 'misc/snippets';
+    mkdirSync(join(workspaceRoot, orphanRoot), { recursive: true });
+    writeFileSync(
+      join(workspaceRoot, orphanRoot, 'stencil.config.ts'),
+      'export const config = {};'
+    );
+
+    const [, createNodesFn] = createNodesV2;
+    const results = await createNodesFn(
+      [`${orphanRoot}/stencil.config.ts`],
+      {},
+      fakeContext(workspaceRoot)
+    );
+
+    expect(results).toEqual([]);
+  });
+
+  it('honours custom target names passed as plugin options', async () => {
+    const projectRoot = 'libs/custom-names';
+    scaffoldStencilProject(workspaceRoot, projectRoot);
+
+    const [, createNodesFn] = createNodesV2;
+    const results = await createNodesFn(
+      [`${projectRoot}/stencil.config.ts`],
+      {
+        buildTargetName: 'stencil-build',
+        serveTargetName: 'stencil-serve',
+        testTargetName: 'stencil-test',
+        e2eTargetName: 'stencil-e2e',
+      },
+      fakeContext(workspaceRoot)
+    );
+
+    const [, result] = results[0];
+    const targets = result.projects[projectRoot].targets;
+    expect(Object.keys(targets).sort()).toEqual([
+      'stencil-build',
+      'stencil-e2e',
+      'stencil-serve',
+      'stencil-test',
+    ]);
+  });
+});
+
+function scaffoldStencilProject(workspaceRoot: string, projectRoot: string) {
+  mkdirSync(join(workspaceRoot, projectRoot), { recursive: true });
+  writeFileSync(
+    join(workspaceRoot, projectRoot, 'stencil.config.ts'),
+    'export const config = {};'
+  );
+  writeFileSync(
+    join(workspaceRoot, projectRoot, 'project.json'),
+    JSON.stringify({ name: projectRoot.split('/').pop(), root: projectRoot })
+  );
+}
+
+function fakeContext(workspaceRoot: string) {
+  return {
+    workspaceRoot,
+    nxJsonConfiguration: {},
+    configFiles: [],
+  };
+}

--- a/packages/stencil/src/plugins/plugin.ts
+++ b/packages/stencil/src/plugins/plugin.ts
@@ -1,0 +1,117 @@
+import {
+  CreateNodesV2,
+  ProjectConfiguration,
+  TargetConfiguration,
+} from '@nx/devkit';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+export interface StencilPluginOptions {
+  buildTargetName?: string;
+  serveTargetName?: string;
+  testTargetName?: string;
+  e2eTargetName?: string;
+}
+
+/**
+ * Infers stencil tasks for any project containing a `stencil.config.ts`.
+ *
+ * Scope-by-design: targets shell out to the local `stencil` CLI via
+ * `nx:run-commands` with `cwd: projectRoot`. No custom executor, no runtime
+ * path rewriting — the stencil config itself is the source of truth for where
+ * output lands (typically `<projectRoot>/www` or `<projectRoot>/dist`, plus
+ * the `<workspaceRoot>/dist/<projectRoot>` convention the @nxext/stencil
+ * generator templates write).
+ *
+ * `{workspaceRoot}/dist/{projectRoot}` is listed as the cache output. That
+ * covers the nxext-generated template's configured output directory. Users
+ * with non-standard stencil output paths should override the inferred `outputs`
+ * locally in their project.json.
+ */
+export const createNodesV2: CreateNodesV2<StencilPluginOptions> = [
+  '**/stencil.config.ts',
+  (configFiles, rawOptions, context) => {
+    const options = normalizeOptions(rawOptions);
+    const workspaceRoot = context.workspaceRoot;
+
+    return configFiles.flatMap((configFile) => {
+      const projectRoot = dirname(configFile);
+
+      const isProject =
+        existsSync(join(workspaceRoot, projectRoot, 'project.json')) ||
+        existsSync(join(workspaceRoot, projectRoot, 'package.json'));
+      if (!isProject) {
+        return [];
+      }
+
+      return [
+        [
+          configFile,
+          {
+            projects: {
+              [projectRoot]: {
+                targets: buildTargets(projectRoot, options),
+                metadata: {
+                  technologies: ['stencil'],
+                },
+              },
+            },
+          },
+        ],
+      ];
+    });
+  },
+];
+
+type NormalizedOptions = Required<StencilPluginOptions>;
+
+function normalizeOptions(
+  options: StencilPluginOptions | undefined
+): NormalizedOptions {
+  return {
+    buildTargetName: options?.buildTargetName ?? 'build',
+    serveTargetName: options?.serveTargetName ?? 'serve',
+    testTargetName: options?.testTargetName ?? 'test',
+    e2eTargetName: options?.e2eTargetName ?? 'e2e',
+  };
+}
+
+function buildTargets(
+  projectRoot: string,
+  options: NormalizedOptions
+): ProjectConfiguration['targets'] {
+  const commonOptions: Partial<TargetConfiguration> = {
+    options: { cwd: projectRoot },
+    metadata: { technologies: ['stencil'] },
+  };
+
+  return {
+    [options.buildTargetName]: {
+      command: 'stencil build',
+      cache: true,
+      inputs: ['default', '^production'],
+      outputs: [
+        `{workspaceRoot}/dist/${projectRoot}`,
+        `{projectRoot}/www`,
+        `{projectRoot}/dist`,
+      ],
+      ...commonOptions,
+    },
+    [options.serveTargetName]: {
+      command: 'stencil build --dev --watch --serve',
+      cache: false,
+      ...commonOptions,
+    },
+    [options.testTargetName]: {
+      command: 'stencil test --spec',
+      cache: true,
+      inputs: ['default', '^production'],
+      ...commonOptions,
+    },
+    [options.e2eTargetName]: {
+      command: 'stencil test --e2e',
+      cache: false,
+      ...commonOptions,
+    },
+  };
+}

--- a/packages/stencil/src/plugins/plugin.ts
+++ b/packages/stencil/src/plugins/plugin.ts
@@ -29,7 +29,7 @@ export interface StencilPluginOptions {
  * locally in their project.json.
  */
 export const createNodesV2: CreateNodesV2<StencilPluginOptions> = [
-  '**/stencil.config.ts',
+  '**/stencil.config*.ts',
   (configFiles, rawOptions, context) => {
     const options = normalizeOptions(rawOptions);
     const workspaceRoot = context.workspaceRoot;

--- a/packages/stencil/src/utils/targets.ts
+++ b/packages/stencil/src/utils/targets.ts
@@ -1,100 +1,25 @@
 import { TargetConfiguration } from '@nx/devkit';
-import { LibrarySchema } from '../generators/library/schema';
-import { ApplicationSchema } from '../generators/application/schema';
-import { MakeLibBuildableSchema } from '../generators/make-lib-buildable/schema';
 import { ProjectType } from '../utils/typings';
 
+/**
+ * The only target the generator writes explicitly is `lint`. `build`, `serve`,
+ * `test`, and `e2e` are inferred by `@nxext/stencil/plugin` (Project Crystal)
+ * from the presence of `stencil.config.ts`. See `packages/stencil/src/plugins/plugin.ts`.
+ *
+ * The legacy `@nxext/stencil:build|serve|test|e2e` executors remain in
+ * `src/executors/` as a backward-compatibility fallback for workspaces that
+ * still reference them explicitly in their project.json.
+ */
 export function getDefaultTargets(
-  projectType: ProjectType,
-  options: LibrarySchema | ApplicationSchema | MakeLibBuildableSchema
+  _projectType: ProjectType,
+  options: { projectRoot: string }
 ): { [key: string]: TargetConfiguration } {
   return {
-    build: getBuildTarget(projectType, options),
-    serve: getServeTarget(projectType, options),
-    test: getTestTarget(projectType, options),
-    e2e: getE2eTarget(projectType, options),
-    lint: getLintTarget(projectType, options.projectRoot),
+    lint: getLintTarget(options.projectRoot),
   };
 }
 
-export function getBuildTarget(
-  projectType: ProjectType,
-  options: LibrarySchema | ApplicationSchema | MakeLibBuildableSchema
-): TargetConfiguration {
-  const tsconfigAddition = projectType === 'application' ? 'app' : 'lib';
-  return {
-    executor: '@nxext/stencil:build',
-    outputs: ['{options.outputPath}'],
-    options: {
-      projectType,
-      tsConfig: `${options.projectRoot}/tsconfig.${tsconfigAddition}.json`,
-      configPath: `${options.projectRoot}/stencil.config.ts`,
-      outputPath: `dist/${options.projectRoot}`,
-    },
-    configurations: {
-      production: {
-        dev: false,
-        prod: true,
-      },
-    },
-  };
-}
-
-export function getTestTarget(
-  projectType: ProjectType,
-  options: LibrarySchema | ApplicationSchema | MakeLibBuildableSchema
-): TargetConfiguration {
-  const tsconfigAddition = projectType === 'application' ? 'app' : 'lib';
-  return {
-    executor: '@nxext/stencil:test',
-    outputs: ['{options.outputPath}'],
-    options: {
-      projectType,
-      tsConfig: `${options.projectRoot}/tsconfig.${tsconfigAddition}.json`,
-      configPath: `${options.projectRoot}/stencil.config.ts`,
-      outputPath: `dist/${options.projectRoot}`,
-    },
-  };
-}
-
-export function getE2eTarget(
-  projectType: ProjectType,
-  options: LibrarySchema | ApplicationSchema | MakeLibBuildableSchema
-): TargetConfiguration {
-  const tsconfigAddition = projectType === 'application' ? 'app' : 'lib';
-  return {
-    executor: '@nxext/stencil:e2e',
-    outputs: ['{options.outputPath}'],
-    options: {
-      projectType,
-      tsConfig: `${options.projectRoot}/tsconfig.${tsconfigAddition}.json`,
-      configPath: `${options.projectRoot}/stencil.config.ts`,
-      outputPath: `dist/${options.projectRoot}`,
-    },
-  };
-}
-
-export function getServeTarget(
-  projectType: ProjectType,
-  options: LibrarySchema | ApplicationSchema | MakeLibBuildableSchema
-): TargetConfiguration {
-  const tsconfigAddition = projectType === 'application' ? 'app' : 'lib';
-  return {
-    executor: `@nxext/stencil:serve`,
-    outputs: ['{options.outputPath}'],
-    options: {
-      projectType,
-      tsConfig: `${options.projectRoot}/tsconfig.${tsconfigAddition}.json`,
-      configPath: `${options.projectRoot}/stencil.config.ts`,
-      outputPath: `dist/${options.projectRoot}`,
-    },
-  };
-}
-
-export function getLintTarget(
-  projectType: ProjectType,
-  projectRoot: string
-): TargetConfiguration {
+export function getLintTarget(projectRoot: string): TargetConfiguration {
   return {
     executor: '@nx/eslint:eslint',
     outputs: ['{options.outputFile}'],

--- a/packages/stencil/src/utils/utillities.ts
+++ b/packages/stencil/src/utils/utillities.ts
@@ -14,10 +14,27 @@ export function calculateStyle(
   return /^(css|scss)$/.test(style) ? style : styleDefault;
 }
 
-export function isBuildableStencilProject(project: any): boolean {
+export function isBuildableStencilProject(
+  project: { root: string; targets?: Record<string, { executor?: string }> },
+  tree?: Tree
+): boolean {
+  // Back-compat: workspaces that still ship an explicit
+  // `@nxext/stencil:build` target in project.json.
   const target =
     project.targets && project.targets['build'] ? project.targets['build'] : {};
-  return target && target.executor === `@nxext/stencil:build`;
+  if (target && target.executor === `@nxext/stencil:build`) {
+    return true;
+  }
+
+  // Crystal path: only buildable libs get a `package.json` at the project
+  // root (written by `make-lib-buildable` / the library generator when
+  // `buildable: true`). Non-buildable libs ship a `stencil.config.ts` too,
+  // but strictly for component authoring — they aren't shippable.
+  if (tree && tree.exists(`${project.root}/package.json`)) {
+    return true;
+  }
+
+  return false;
 }
 
 export const hasError = (diagnostics: Diagnostic[]): boolean => {


### PR DESCRIPTION
## Summary

- Introduces `@nxext/stencil/plugin` (`createNodesV2`) that infers `build`/`serve`/`test`/`e2e` targets from the presence of a `stencil.config.ts` at a project root.
- Stops the application/library/make-lib-buildable generators from writing those four targets into `project.json` explicitly — `lint` is still written, everything else comes from the plugin.
- The four legacy executors (`@nxext/stencil:build|serve|test|e2e`) stay in place as a backward-compat fallback for workspaces that reference them directly. Removing them is a follow-up gated on adoption.

## What changed

- **New** `packages/stencil/src/plugins/plugin.ts` + `plugin.spec.ts` — Crystal plugin. Shells out to the local `stencil` CLI via `nx:run-commands` with `cwd: projectRoot`, so the stencil config is the source of truth for output paths.
- `packages/stencil/package.json` — new `exports` block including `./plugin`.
- `packages/stencil/src/generators/init/init.ts` — registers `@nxext/stencil/plugin` in `nx.json.plugins` via the existing `addPluginToNxJson` helper.
- `packages/stencil/src/utils/targets.ts` — keeps only `getLintTarget`; `getBuildTarget`/`getServeTarget`/`getTestTarget`/`getE2eTarget` deleted.
- `packages/stencil/src/generators/library/lib/add-project.ts` + `make-lib-buildable/make-lib-buildable.ts` — no longer write build/serve/test/e2e explicitly.
- `packages/stencil/src/utils/utillities.ts` — `isBuildableStencilProject` now also treats "has a `package.json` at the project root" as buildable (Crystal path), in addition to the legacy "has an `@nxext/stencil:build` target" check.
- Updated library generator specs to assert `stencil.config.ts` exists (proxy for "Crystal will infer build targets") rather than asserting a literal `build` target in `project.json`.

## Test plan

- [x] `pnpm exec nx run stencil:test --skip-nx-cache` — 64 passing (3 new in `plugin.spec.ts`, 1 new in `init.spec.ts`, updated library generator specs)
- [x] `pnpm exec nx run stencil:build` — plugin source compiles, `dist/packages/stencil/src/plugins/plugin.js` present
- [ ] `pnpm exec nx run stencil-e2e:e2e --skip-nx-cache` — verify existing e2e tests still pass (they call `nx build <app>` which now resolves to the inferred target)
- [ ] Manual smoke in a scratch workspace: add `@nxext/stencil/plugin` to `nx.json.plugins`, drop a `stencil.config.ts` under `apps/demo/`, run `nx show project demo` — `build`/`serve`/`test`/`e2e` should appear without anything in `apps/demo/project.json`

## Follow-ups (separate PRs)

1. Remove the four custom executors once adoption is proven — migration rewrites explicit `"executor": "@nxext/stencil:build"` in existing `project.json` files.
2. Migrate `packages/svelte/src/graph/processProjectGraph.ts` to the new `createDependencies` graph plugin API (independent from this Crystal tasks work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)